### PR TITLE
Add LevelFilterWithOrigin log filter

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,22 +1,10 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
-;; (
-;;  (go-mode
-;;   . ((eval
-;;       . (let
-;; 	    ((sqlite-path
-;; 	      (concat (file-name-directory (dir-locals-find-file ".")) ".sqlite/")))
-;; 	  (progn
-;; 	    (setenv "CGO_CFLAGS" (concat "-I" sqlite-path))
-;; 	    (setenv "CGO_LDFLAGS" (concat "-L" sqlite-path))
-;; 	    (setenv "LD_LIBRARY_PATH" sqlite-path))))
-;;      (go-test-args . "-tags libsqlite3")
-;;      )))
 (
  (go-mode
   . ((go-test-args . "-tags libsqlite3")
      (eval
-      . (let* ((locals-path (let ((d (dir-locals-find-file "."))) (if (stringp d) d (car d))))
+      . (let* ((locals-path (let ((d (dir-locals-find-file "."))) (if (stringp d) (file-name-directory d) (car d))))
 	       (sqlite-path (concat locals-path ".sqlite/")))
  	  (progn
  	    (setenv "CGO_CFLAGS" (concat "-I" sqlite-path))

--- a/log.go
+++ b/log.go
@@ -1,8 +1,10 @@
 package dqlite
 
 import (
+	"bytes"
 	"io"
 	"log"
+	"sync"
 
 	"github.com/hashicorp/logutils"
 )
@@ -21,4 +23,73 @@ func NewLogger(output io.Writer, level string, flag int) *log.Logger {
 	}
 
 	return log.New(filter, "", flag)
+}
+
+// LevelFilterWithOrigin is an io.Writer that can be used with a logger that
+// will filter out log messages that aren't at least a certain level or that
+// don't match a certain origin.
+//
+// A message is considered having a certain level and origin if it's of the
+// form:
+//
+//   "[<level>] <origin>: <body>"
+//
+// If no level and origin are given, the message will passthrough.
+type LevelFilterWithOrigin struct {
+	logutils.LevelFilter
+	Origins []string
+
+	goodOrigins map[string]struct{}
+	once        sync.Once
+}
+
+func (f *LevelFilterWithOrigin) Write(p []byte) (n int, err error) {
+	// Note in general that io.Writer can receive any byte sequence
+	// to write, but the "log" package always guarantees that we only
+	// get a single line. We use that as a slight optimization within
+	// this method, assuming we're dealing with a single, complete line
+	// of log data.
+
+	if !f.Check(p) {
+		return len(p), nil
+	}
+
+	return f.Writer.Write(p)
+}
+
+// Check will check if a given line should be included in the filter.
+func (f *LevelFilterWithOrigin) Check(line []byte) bool {
+	if !f.LevelFilter.Check(line) {
+		return false
+	}
+
+	if f.Origins == nil {
+		return true
+	}
+
+	f.once.Do(f.init)
+
+	var origin string
+	if x := bytes.IndexByte(line, ']'); x > 0 {
+		if y := bytes.IndexByte(line, ':'); y > 0 {
+			origin = string(line[x+2 : y])
+		}
+	}
+
+	_, ok := f.goodOrigins[origin]
+	return ok
+}
+
+// SetOrigins is used to update the accepted origins. Pass nil for all origins.
+func (f *LevelFilterWithOrigin) SetOrigins(origins []string) {
+	f.Origins = origins
+	f.init()
+}
+
+func (f *LevelFilterWithOrigin) init() {
+	f.goodOrigins = make(map[string]struct{})
+	f.goodOrigins[""] = struct{}{}
+	for _, origin := range f.Origins {
+		f.goodOrigins[origin] = struct{}{}
+	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,48 @@
+package dqlite_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/CanonicalLtd/dqlite"
+	"github.com/hashicorp/logutils"
+)
+
+func TestLevelFilterWithOrigin_Write(t *testing.T) {
+	writer := bytes.NewBuffer(nil)
+	filter := &dqlite.LevelFilterWithOrigin{}
+	filter.Writer = writer
+	filter.Levels = []logutils.LogLevel{"DEBUG", "INFO"}
+	filter.MinLevel = "INFO"
+	filter.Origins = []string{"foo"}
+
+	cases := []struct {
+		origins []string
+		message string
+		written bool
+	}{
+		{[]string{"foo"}, "[INFO] foo: hello", true},
+		{[]string{"foo"}, "[DEBUG] foo: hello", false},
+		{[]string{"foo"}, "[INFO] bar: hello", false},
+		{[]string{"foo"}, "foo: hello", true},
+		{[]string{"foo"}, "hello", true},
+		{nil, "[INFO] bar: hello", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.message, func(t *testing.T) {
+			defer writer.Reset()
+			filter.SetOrigins(c.origins)
+
+			filter.Write([]byte(c.message))
+
+			want := ""
+			if c.written {
+				want = c.message
+			}
+			if got := writer.String(); got != want {
+				t.Errorf("got %#v, wanted %#v", got, want)
+			}
+		})
+	}
+}

--- a/testdata/demo.go
+++ b/testdata/demo.go
@@ -54,13 +54,12 @@ func main() {
 	// for the DQLite cluster. In a real-world web service you'll
 	// want to route the Raft HTTP handler to some specific path,
 	// not "/".
-	listener, err := net.Listen("tcp", fmt.Sprintf(*addr))
+	listener, err := net.Listen("tcp", *addr)
 	if err != nil {
 		log.Fatalf("[ERR] demo: failed to listen to address %s: %v", *addr, err)
 	}
 	handler := rafthttp.NewHandler()
-	server := &http.Server{Handler: handler}
-	go server.Serve(listener)
+	go http.Serve(listener, handler)
 	addr := listener.Addr()
 
 	prefix := fmt.Sprintf("%s: ", addr)


### PR DESCRIPTION
The new LevelFilterWithOrigin type extends Hashicorp's LevelFilter by
also supporting filtering by "origin", which is an additional string
following the level.