### PR TITLE
Serialize transactions started by different leader connections

### DIFF
--- a/internal/replication/fsm_test.go
+++ b/internal/replication/fsm_test.go
@@ -68,7 +68,7 @@ var fsmApplyPanicCases = []struct {
 			defer cleanup()
 
 			fsm.Connections().AddLeader("test.db", conn)
-			fsm.Transactions().AddLeader(conn, "xxxx")
+			fsm.Transactions().AddLeader(conn, "xxxx", nil)
 
 			fsm.Apply(newRaftLog(0, protocol.NewOpen("test.db")))
 			fsm.Apply(newRaftLog(1, protocol.NewBegin("abcd", "test.db")))
@@ -125,7 +125,7 @@ var fsmApplyCases = []struct {
 			conn, cleanup := newLeaderConn(t, fsm.Dir(), methods)
 			defer cleanup()
 
-			txn := fsm.Transactions().AddLeader(conn, "0")
+			txn := fsm.Transactions().AddLeader(conn, "0", nil)
 			txn.DryRun(true)
 
 			fsm.Apply(newRaftLog(0, protocol.NewBegin("0", "test.db")))

--- a/internal/transaction/registry_test.go
+++ b/internal/transaction/registry_test.go
@@ -12,7 +12,7 @@ func TestRegistry_AddLeader(t *testing.T) {
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "1")
+	txn := registry.AddLeader(conn, "1", nil)
 
 	if txn.ID() == "" {
 		t.Error("no ID assigned to transaction")
@@ -29,7 +29,7 @@ func TestRegistry_AddLeaderPanicsIfPassedSameLeaderConnectionTwice(t *testing.T)
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "1")
+	txn := registry.AddLeader(conn, "1", nil)
 
 	want := fmt.Sprintf("a transaction for this connection is already registered with ID %s", txn.ID())
 	defer func() {
@@ -38,7 +38,7 @@ func TestRegistry_AddLeaderPanicsIfPassedSameLeaderConnectionTwice(t *testing.T)
 			t.Errorf("expected\n%q\ngot\n%q", want, got)
 		}
 	}()
-	registry.AddLeader(conn, "2")
+	registry.AddLeader(conn, "2", nil)
 }
 
 func TestRegistry_AddFollower(t *testing.T) {
@@ -62,7 +62,7 @@ func TestRegistry_GetByID(t *testing.T) {
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	if registry.GetByID(txn.ID()) != txn {
 		t.Error("transactions instances don't match")
 	}
@@ -79,7 +79,7 @@ func TestRegistry_GetByConn(t *testing.T) {
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	if registry.GetByConn(conn) != txn {
 		t.Error("transactions instances don't match")
 	}
@@ -98,7 +98,7 @@ func TestRegistry_Remove(t *testing.T) {
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 
 	registry.Remove(txn.ID())
 	if registry.GetByID(txn.ID()) != nil {

--- a/internal/transaction/txn_test.go
+++ b/internal/transaction/txn_test.go
@@ -138,7 +138,7 @@ func TestTxn_StaleFromPending(t *testing.T) {
 	registry := newRegistry()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	txn.Enter()
 
 	txn.DryRun(true)
@@ -157,7 +157,7 @@ func TestTxn_StaleFromStarted(t *testing.T) {
 	registry.DryRun()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	txn.Enter()
 
 	txn.DryRun(true)
@@ -180,7 +180,7 @@ func TestTxn_StaleFromWriting(t *testing.T) {
 	registry.DryRun()
 
 	conn := &sqlite3.SQLiteConn{}
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	txn.Enter()
 
 	txn.DryRun(true)
@@ -212,7 +212,7 @@ func TestTxn_StaleFromUndoing(t *testing.T) {
 	// Pretend that the follower transaction is the leader, since
 	// invoking Begin() on an actual leader connection would fail
 	// because the WAL has not started a read transaction.
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	txn.Enter()
 
 	txn.DryRun(true)
@@ -238,7 +238,7 @@ func TestTxn_StaleFromEnded(t *testing.T) {
 
 	conn := &sqlite3.SQLiteConn{}
 
-	txn := registry.AddLeader(conn, "0")
+	txn := registry.AddLeader(conn, "0", nil)
 	txn.Enter()
 
 	txn.DryRun(true)


### PR DESCRIPTION
Since for some reason sqlite doesn't seem to serialize the pager
transactions, this commit does that inside dqlite itself.