### PR TITLE
Return ErrBusy immediately if a txn is ongoing, without retrying

### DIFF
--- a/options.go
+++ b/options.go
@@ -65,6 +65,7 @@ func newOptions() *options {
 		logFunc:        log.Standard(),
 		logLevel:       "INFO",
 		barrierTimeout: time.Minute,
+		applyTimeout:   10 * time.Second,
 		autoCheckpoint: 1000,
 	}
 }


### PR DESCRIPTION
The retry logic will be handled by the Go sql code or by
application-level logic.