### PR TITLE
Copy dynamic data returned by the configured dqlite_cluster implementation

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -461,7 +461,7 @@ int dqlite_server_handle(dqlite_server *s, int fd, char **errmsg) {
 		goto err_not_running_or_conn_malloc;
 	}
 
-	conn = (struct dqlite__conn *)sqlite3_malloc(sizeof(*conn));
+	conn = sqlite3_malloc(sizeof(*conn));
 	if (conn == NULL) {
 		dqlite__error_oom(&e, "failed to allocate connection");
 		err = DQLITE_NOMEM;

--- a/test/test_gateway.c
+++ b/test/test_gateway.c
@@ -169,6 +169,10 @@ static MunitResult test_leader(const MunitParameter params[], void *data) {
 
 	munit_assert_string_equal(f->response->server.address, "127.0.0.1:666");
 
+	/* Invoke the reset callback, as it would be if the response was then
+	 * being encoded. */
+	f->response->xReset(f->response);
+
 	return MUNIT_OK;
 }
 
@@ -214,6 +218,10 @@ static MunitResult test_heartbeat(const MunitParameter params[], void *data) {
 	munit_assert_string_equal(f->response->servers.servers[1].address,
 	                          "5.6.7.8:666");
 	munit_assert_ptr_equal(f->response->servers.servers[2].address, NULL);
+
+	/* Invoke the reset callback, as it would be if the response was then
+	 * being encoded. */
+	f->response->xReset(f->response);
 
 	return MUNIT_OK;
 }
@@ -996,13 +1004,13 @@ static MunitResult test_max_requests(const MunitParameter params[], void *data) 
 	(void)params;
 
 	for (i = 0; i < DQLITE__GATEWAY_MAX_REQUESTS; i++) {
-		f->request->type = DQLITE_REQUEST_LEADER;
+		f->request->type = DQLITE_REQUEST_CLIENT;
 
 		err = dqlite__gateway_handle(f->gateway, f->request, &f->response);
 		munit_assert_int(err, ==, 0);
 	}
 
-	f->request->type = DQLITE_REQUEST_LEADER;
+	f->request->type = DQLITE_REQUEST_CLIENT;
 
 	err = dqlite__gateway_handle(f->gateway, f->request, &f->response);
 	munit_assert_int(err, ==, DQLITE_PROTO);


### PR DESCRIPTION
This leaves the dqlite_cluster implementation itself free to release the memory it
returns.