### PR TITLE
Fix race in the connection abort sequence

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -51,6 +51,7 @@ struct dqlite__conn {
 	uv_buf_t   buf;   /* Read buffer */
 
 	uint64_t timestamp; /* Time at which the current request started. */
+	int      aborting;  /* True if we started to abort the connetion */
 };
 
 /* Initialize a connection object */

--- a/src/server.c
+++ b/src/server.c
@@ -517,9 +517,9 @@ err_item_init_or_queue_push:
 	sqlite3_free(conn);
 
 err_not_running_or_conn_malloc:
-	err = dqlite__error_copy(&e, errmsg);
-	if (err != 0)
+	if (dqlite__error_copy(&e, errmsg) != 0) {
 		*errmsg = "error message unavailable (out of memory)";
+	}
 
 	dqlite__error_close(&e);
 


### PR DESCRIPTION
The current uv_is_closing((uv_handle_t *)(&c->stream)) check is
dqlite__conn_abort() doesn't seem to be effective enough, and probably
uv_is_closing() sometimes returns 0 even if we already called uv_close().

A new conn->aborting attribute has been added to track the connection state
internally in dqlite.