### PR TITLE
Allow releasing a shared-memory lock before acquiring it.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,8 @@ dqlite_test_SOURCES = \
   test/client.h \
   test/cluster.c \
   test/cluster.h \
+  test/fs.c \
+  test/fs.h \
   test/leak.c \
   test/leak.h \
   test/log.c \

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1277,11 +1277,12 @@ static int dqlite__vfs_shm_lock(sqlite3_file *file,
 			 * in this region. */
 			assert(other_locks[i] == 0);
 
-			/* Sanity check that there is at least one lock held for
-			 * this index. */
-			assert(these_locks[i] > 0);
-
-			these_locks[i]--;
+			/* Only decrease the lock count if it's positive. In
+			 * other words releasing a never acquired lock is legal
+			 * and idemponent. */
+			if (these_locks[i] > 0) {
+				these_locks[i]--;
+			}
 		}
 	} else {
 		if (flags & SQLITE_SHM_EXCLUSIVE) {

--- a/test/fs.c
+++ b/test/fs.c
@@ -1,0 +1,46 @@
+#define _GNU_SOURCE
+
+#include <ftw.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "fs.h"
+#include "munit.h"
+
+const char *test_dir_setup() {
+	char *dir = munit_malloc(strlen(TEST__DIR_TEMPLATE) + 1);
+
+	strcpy(dir, TEST__DIR_TEMPLATE);
+
+	munit_assert_ptr_not_null(mkdtemp(dir));
+
+	return dir;
+}
+
+static int test__dir_tear_down_nftw_fn(const char *       path,
+                                       const struct stat *sb,
+                                       int                type,
+                                       struct FTW *       ftwb) {
+	int rc;
+
+	(void)sb;
+	(void)type;
+	(void)ftwb;
+
+	rc = remove(path);
+	munit_assert_int(rc, ==, 0);
+
+	return 0;
+}
+
+void test_dir_tear_down(const char *dir) {
+	int rc;
+
+	rc = nftw(dir,
+	          test__dir_tear_down_nftw_fn,
+	          10,
+	          FTW_DEPTH | FTW_MOUNT | FTW_PHYS);
+	munit_assert_int(rc, ==, 0);
+}

--- a/test/fs.h
+++ b/test/fs.h
@@ -1,0 +1,12 @@
+#ifndef DQLITE_TEST_FS_H
+#define DQLITE_TEST_FS_H
+
+#define TEST__DIR_TEMPLATE "/tmp/dqlite-test-XXXXXX"
+
+/* Setup a temporary directory. */
+const char *test_dir_setup();
+
+/* Remove the temporary directory. */
+void test_dir_tear_down(const char *dir);
+
+#endif /* DQLITE_TEST_FS_H */


### PR DESCRIPTION
Apparently this might happen in SQLite when opening a database.