### PR TITLE
Make dqlite__gateway's API asynchronous

### DIFF
--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -35,6 +35,7 @@
 #define DQLITE_REQUEST_FINALIZE 7
 #define DQLITE_REQUEST_EXEC_SQL 8
 #define DQLITE_REQUEST_QUERY_SQL 9
+#define DQLITE_REQUEST_INTERRUPT 10 /* TODO: implement */
 
 /* Response types */
 #define DQLITE_RESPONSE_FAILURE 0
@@ -166,7 +167,8 @@ const char *dqlite_server_errmsg(dqlite_server *s);
 /* Return the dqlite_cluster object used to initialize the server */
 dqlite_cluster *dqlite_server_cluster(dqlite_server *s);
 
-/* Return the dqlite_logger object the server is using, if any was configured. */
+/* Return the dqlite_logger object the server is using, if any was configured.
+ */
 dqlite_logger *dqlite_server_logger(dqlite_server *s);
 
 /* Allocate and initialize an in-memory dqlite VFS object, configured with the

--- a/src/conn.h
+++ b/src/conn.h
@@ -33,12 +33,13 @@ struct dqlite__conn {
 	uint64_t      protocol; /* Protocol version */
 
 	/* private */
-	struct dqlite__metrics *metrics;  /* Operational metrics */
-	struct dqlite__options *options;  /* Connection state machine */
-	struct dqlite__fsm      fsm;      /* Connection state machine */
-	struct dqlite__gateway  gateway;  /* Client state and request handler */
-	struct dqlite__request  request;  /* Incoming request */
-	struct dqlite__response response; /* Response buffer for internal failures */
+	struct dqlite__metrics *metrics; /* Operational metrics */
+	struct dqlite__options *options; /* Connection state machine */
+	struct dqlite__fsm      fsm;     /* Connection state machine */
+	struct dqlite__gateway  gateway; /* Client state and request handler */
+	struct dqlite__request  request; /* Incoming request */
+	struct dqlite__response
+	    response; /* Response buffer for internal failures */
 
 	int        fd;   /* File descriptor of client stream */
 	uv_loop_t *loop; /* UV loop */
@@ -52,6 +53,7 @@ struct dqlite__conn {
 
 	uint64_t timestamp; /* Time at which the current request started. */
 	int      aborting;  /* True if we started to abort the connetion */
+	int      paused;    /* True if we have paused reading from the stream */
 };
 
 /* Initialize a connection object */

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -1,3 +1,9 @@
+/******************************************************************************
+ *
+ * Core dqlite server engine, calling out SQLite for serving client requests.
+ *
+ *****************************************************************************/
+
 #ifndef DQLITE_GATEWAY_H
 #define DQLITE_GATEWAY_H
 
@@ -14,13 +20,7 @@
 #include "request.h"
 #include "response.h"
 
-/* Maximum number of requests that can be served concurrently.
- *
- * TODO: this should be reduced to 5 or 3. The problem is that some new request
- * might come in before the response for the last request has been completely
- * written out.
- */
-#define DQLITE__GATEWAY_MAX_REQUESTS 20
+#define DQLITE__GATEWAY_MAX_REQUESTS 2
 
 /* Context for the gateway request handlers */
 struct dqlite__gateway_ctx {
@@ -28,8 +28,21 @@ struct dqlite__gateway_ctx {
 	struct dqlite__response response;
 };
 
+/* Callbacks that the gateway will invoke during the various phases of request
+ * handling. */
+struct dqlite__gateway_cbs {
+	void *ctx; /* Context to pass to the callbacks. */
+
+	/* Invoked when a respone is available. User code is expected to invoke
+	 * dqlite__gateway_flushed() to indicate that it has completed sending
+	 * the response data to the client and that the response buffer can be
+	 * used for another request. */
+	void (*xFlush)(void *ctx, struct dqlite__response *response);
+};
+
 /*
- * Handle requests from a single connected client and forward them to SQLite.
+ * Handle requests from a single connected client and forward them to
+ * SQLite.
  */
 struct dqlite__gateway {
 	/* read-only */
@@ -38,40 +51,63 @@ struct dqlite__gateway {
 	dqlite__error error;     /* Last error occurred, if any */
 
 	/* private */
-	dqlite_cluster *        cluster; /* Cluster interface implementation */
-	struct dqlite__options *options; /* Configuration options */
+	struct dqlite__gateway_cbs callbacks; /* User callbacks */
+	dqlite_cluster *           cluster;   /* Cluster API implementation  */
+	struct dqlite__options *   options;   /* Configuration options */
 
-	/*
-	 * Clients are expected to issue one SQL request at a time and wait for
-	 * the response, plus possibly some concurrent requests such as
-	 * Heartbeat or Interrupt. So we don't need a lot of concurrency.
-	 */
+	/* Buffer holding responses for in-progress requests. Clients are
+	 * expected to issue one SQL request at a time and wait for the
+	 * response, plus possibly some concurrent control requests such as an
+	 * heartbeat or interrupt. */
 	struct dqlite__gateway_ctx ctxs[DQLITE__GATEWAY_MAX_REQUESTS];
 
 	struct dqlite__db_registry dbs; /* Registry of open databases */
 };
 
-void dqlite__gateway_init(struct dqlite__gateway *g,
-                          struct dqlite_cluster * cluster,
-                          struct dqlite__options *options);
+void dqlite__gateway_init(struct dqlite__gateway *    g,
+                          struct dqlite__gateway_cbs *callbacks,
+                          struct dqlite_cluster *     cluster,
+                          struct dqlite__options *    options);
 
 void dqlite__gateway_close(struct dqlite__gateway *g);
 
-/* Handle a new client request */
-int dqlite__gateway_handle(struct dqlite__gateway *  g,
-                           struct dqlite__request *  request,
-                           struct dqlite__response **response);
+/* Start handling a new client request.
+ *
+ * Responses for requests that can be handled synchronously will be generated
+ * immediately and the xFlush() callback will be invoked inline, before this
+ * function returns.
+ *
+ * Responses for requests that need to perform network or disk I/O will be
+ * generated asynchronously and xFlush() will be invoked when done.
+ *
+ * Some requests might generate more than one response (for example when a
+ * SELECT query yields a large number of rows). In that case xFlush() will be
+ * invoked more than once.
+ *
+ * Generally at most one request can be outstanding at any given time. This
+ * function will return an error if user code calls it and there's already a
+ * request in progress. The only exceptions to this rule are heartbeat and
+ * interrupt requests, that will be handled synchronously regardless of whether
+ * there's already a request in progress.
+ *
+ * User code can check whether the gateway would currently accept a request of a
+ * certain type by calling dqlite__gateway_ok_to_accept.
+ */
+int dqlite__gateway_handle(struct dqlite__gateway *g,
+                           struct dqlite__request *request);
 
-/* Continue serving a request after the first write (for result sets) */
-int dqlite__gateway_continue(struct dqlite__gateway * g,
+/* Return true if at the moment the gateway can accept a new request of the
+ * given type. */
+int dqlite__gateway_ok_to_accept(struct dqlite__gateway *g, int type);
+
+/* Notify the gateway that a response has been completely flushed and its data
+ * sent to the client. */
+void dqlite__gateway_flushed(struct dqlite__gateway * g,
                              struct dqlite__response *response);
 
-/* Complete a request after the response has been written */
-void dqlite__gateway_finish(struct dqlite__gateway * g,
-                            struct dqlite__response *response);
-
-/* Abort a request */
-void dqlite__gateway_abort(struct dqlite__gateway * g,
-                           struct dqlite__response *response);
+/* Notify the gateway that this response has been aborted due to errors
+ * (e.g. the client disconnected). */
+void dqlite__gateway_aborted(struct dqlite__gateway * g,
+                             struct dqlite__response *response);
 
 #endif /* DQLITE_GATEWAY_H */

--- a/src/replication.h
+++ b/src/replication.h
@@ -4,8 +4,8 @@
  *
  *****************************************************************************/
 
-#ifndef DQLITE_OS_H
-#define DQLITE_OS_H
+#ifndef DQLITE_REPLICATION_H
+#define DQLITE_REPLICATION_H
 
 #ifdef DQLITE_EXPERIMENTAL
 
@@ -46,4 +46,4 @@ int dqlite__replication_end(sqlite3_wal_replication *r, void *arg);
 
 #endif /* DQLITE_EXPERIMENTAL */
 
-#endif /* DQLITE_OS_H */
+#endif /* DQLITE_REPLICATION_H */

--- a/src/schema.h
+++ b/src/schema.h
@@ -20,11 +20,12 @@
  * P:      Pointer to the message schema object.
  * M:      Pointer to the underlying message.
  * E:      Pointer to the error to fill in case of failures. */
-#define __DQLITE__SCHEMA_FIELD_PUT(KIND, MEMBER, P, M, E)                           \
-	err = dqlite__message_body_put_##KIND(M, (P)->MEMBER);                      \
-	if (err != 0 && err != DQLITE_EOM) {                                        \
-		dqlite__error_wrapf(E, &(M)->error, "failed to put %s", #MEMBER);   \
-		return err;                                                         \
+#define __DQLITE__SCHEMA_FIELD_PUT(KIND, MEMBER, P, M, E)                      \
+	err = dqlite__message_body_put_##KIND(M, (P)->MEMBER);                 \
+	if (err != 0 && err != DQLITE_EOM) {                                   \
+		dqlite__error_wrapf(                                           \
+		    E, &(M)->error, "failed to put %s", #MEMBER);              \
+		return err;                                                    \
 	}
 
 /* Decode a single field in message schema.
@@ -34,12 +35,12 @@
  * P:      Pointer to the message schema object.
  * M:      Pointer to the underlying message.
  * E:      Pointer to the error to fill in case of failures. */
-#define __DQLITE__SCHEMA_FIELD_GET(KIND, MEMBER, P, M, E)                           \
-	err = dqlite__message_body_get_##KIND(M, &(P)->MEMBER);                     \
-	if (err != 0 && err != DQLITE_EOM) {                                        \
-		dqlite__error_wrapf(                                                \
-		    E, &(M)->error, "failed to get '%s' field", #MEMBER);           \
-		return err;                                                         \
+#define __DQLITE__SCHEMA_FIELD_GET(KIND, MEMBER, P, M, E)                      \
+	err = dqlite__message_body_get_##KIND(M, &(P)->MEMBER);                \
+	if (err != 0 && err != DQLITE_EOM) {                                   \
+		dqlite__error_wrapf(                                           \
+		    E, &(M)->error, "failed to get '%s' field", #MEMBER);      \
+		return err;                                                    \
 	}
 
 /* Define a new schema object.
@@ -47,48 +48,49 @@
  * NAME:   Name of the structure which will be defined.
  * SCHEMA: List of X-based macros defining the fields in the schema, in the form
  *         of X(KIND, NAME, __VA_ARGS__). E.g. X(uint64, id, __VA_ARGS__). */
-#define DQLITE__SCHEMA_DEFINE(NAME, SCHEMA)                                         \
-	struct NAME {                                                               \
-		SCHEMA(__DQLITE__SCHEMA_FIELD_DEFINE, )                             \
-	};                                                                          \
-                                                                                    \
-	int NAME##_put(                                                             \
-	    struct NAME *p, struct dqlite__message *m, dqlite__error *e);           \
-                                                                                    \
-	int NAME##_get(struct NAME *p, struct dqlite__message *m, dqlite__error *e)
+#define DQLITE__SCHEMA_DEFINE(NAME, SCHEMA)                                    \
+	struct NAME {                                                          \
+		SCHEMA(__DQLITE__SCHEMA_FIELD_DEFINE, )                        \
+	};                                                                     \
+                                                                               \
+	int NAME##_put(                                                        \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e);      \
+                                                                               \
+	int NAME##_get(                                                        \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e)
 
 /* Implement a new schema object.
  *
  * NAME:   Name of the structure which will be defined.
  * SCHEMA: List of X-macros defining the fields in the schema, in the form
  *         of X(KIND, NAME, __VA_ARGS__). E.g. X(uint64, id, __VA_ARGS__). */
-#define DQLITE__SCHEMA_IMPLEMENT(NAME, SCHEMA)                                      \
-                                                                                    \
-	int NAME##_put(                                                             \
-	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {          \
-		int err;                                                            \
-                                                                                    \
-		assert(p != NULL);                                                  \
-		assert(m != NULL);                                                  \
-                                                                                    \
-		SCHEMA(__DQLITE__SCHEMA_FIELD_PUT, p, m, e);                        \
-                                                                                    \
-		return 0;                                                           \
-	};                                                                          \
-                                                                                    \
-	int NAME##_get(                                                             \
-	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {          \
-		int err;                                                            \
-                                                                                    \
-		assert(p != NULL);                                                  \
-		assert(m != NULL);                                                  \
-                                                                                    \
-		SCHEMA(__DQLITE__SCHEMA_FIELD_GET, p, m, e);                        \
-                                                                                    \
-		return 0;                                                           \
+#define DQLITE__SCHEMA_IMPLEMENT(NAME, SCHEMA)                                 \
+                                                                               \
+	int NAME##_put(                                                        \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {     \
+		int err;                                                       \
+                                                                               \
+		assert(p != NULL);                                             \
+		assert(m != NULL);                                             \
+                                                                               \
+		SCHEMA(__DQLITE__SCHEMA_FIELD_PUT, p, m, e);                   \
+                                                                               \
+		return 0;                                                      \
+	};                                                                     \
+                                                                               \
+	int NAME##_get(                                                        \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {     \
+		int err;                                                       \
+                                                                               \
+		assert(p != NULL);                                             \
+		assert(m != NULL);                                             \
+                                                                               \
+		SCHEMA(__DQLITE__SCHEMA_FIELD_GET, p, m, e);                   \
+                                                                               \
+		return 0;                                                      \
 	}
 
-#define __DQLITE__SCHEMA_HANDLER_FIELD_DEFINE(CODE, STRUCT, NAME, _)                \
+#define __DQLITE__SCHEMA_HANDLER_FIELD_DEFINE(CODE, STRUCT, NAME, _)           \
 	struct STRUCT NAME;
 
 /* Define a new schema handler.
@@ -102,121 +104,112 @@
  *        structure as defined with DQLITE__SCHEMA_DEFINE and NAME is the name
  *        of the field holding this schema object in the schema handler.
  * */
-#define DQLITE__SCHEMA_HANDLER_DEFINE(NAME, TYPES)                                  \
-	struct NAME {                                                               \
-		struct dqlite__message message;                                     \
-		uint64_t               timestamp;                                   \
-		uint8_t                type;                                        \
-		uint8_t                flags;                                       \
-		dqlite__error          error;                                       \
-		union {                                                             \
-			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_DEFINE, )              \
-		};                                                                  \
-                                                                                    \
-		/* Optional hook for resetting the object state after it has        \
-		 * been encoded (e.g. free strings). */                             \
-		void (*xReset)(struct NAME * h);                                    \
-	};                                                                          \
-                                                                                    \
-	void NAME##_init(struct NAME *h);                                           \
-                                                                                    \
-	void NAME##_close(struct NAME *h);                                          \
-                                                                                    \
-	int NAME##_encode(struct NAME *h);                                          \
-                                                                                    \
+#define DQLITE__SCHEMA_HANDLER_DEFINE(NAME, TYPES)                             \
+	struct NAME {                                                          \
+		struct dqlite__message message;                                \
+		uint64_t               timestamp;                              \
+		uint8_t                type;                                   \
+		uint8_t                flags;                                  \
+		dqlite__error          error;                                  \
+		union {                                                        \
+			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_DEFINE, )         \
+		};                                                             \
+	};                                                                     \
+                                                                               \
+	void NAME##_init(struct NAME *h);                                      \
+                                                                               \
+	void NAME##_close(struct NAME *h);                                     \
+                                                                               \
+	int NAME##_encode(struct NAME *h);                                     \
+                                                                               \
 	int NAME##_decode(struct NAME *h)
 
-#define __DQLITE__SCHEMA_HANDLER_FIELD_PUT(CODE, STRUCT, NAME, _)                   \
-	case CODE:                                                                  \
-		err = STRUCT##_put(&h->NAME, &h->message, &h->error);               \
+#define __DQLITE__SCHEMA_HANDLER_FIELD_PUT(CODE, STRUCT, NAME, _)              \
+	case CODE:                                                             \
+		err = STRUCT##_put(&h->NAME, &h->message, &h->error);          \
 		break;
 
-#define __DQLITE__SCHEMA_HANDLER_FIELD_GET(CODE, STRUCT, NAME, _)                   \
-	case CODE:                                                                  \
-                                                                                    \
-		err = STRUCT##_get(&h->NAME, &h->message, &h->error);               \
-		if (err != 0) {                                                     \
-			dqlite__error_wrapf(                                        \
-			    &h->error, &h->error, "failed to decode '%s'", #NAME);  \
-			return err;                                                 \
-		}                                                                   \
-                                                                                    \
+#define __DQLITE__SCHEMA_HANDLER_FIELD_GET(CODE, STRUCT, NAME, _)              \
+	case CODE:                                                             \
+                                                                               \
+		err = STRUCT##_get(&h->NAME, &h->message, &h->error);          \
+		if (err != 0) {                                                \
+			dqlite__error_wrapf(&h->error,                         \
+			                    &h->error,                         \
+			                    "failed to decode '%s'",           \
+			                    #NAME);                            \
+			return err;                                            \
+		}                                                              \
+                                                                               \
 		break;
 
 /* Implement a new schema handler. */
-#define DQLITE__SCHEMA_HANDLER_IMPLEMENT(NAME, TYPES)                               \
-                                                                                    \
-	void NAME##_init(struct NAME *h) {                                          \
-		assert(h != NULL);                                                  \
-                                                                                    \
-		h->type  = 0;                                                       \
-		h->flags = 0;                                                       \
-                                                                                    \
-		dqlite__message_init(&h->message);                                  \
-		dqlite__error_init(&h->error);                                      \
-                                                                                    \
-		h->xReset = NULL;                                                   \
-                                                                                    \
-		dqlite__lifecycle_init(DQLITE__LIFECYCLE_ENCODER);                  \
-	};                                                                          \
-                                                                                    \
-	void NAME##_close(struct NAME *h) {                                         \
-		assert(h != NULL);                                                  \
-                                                                                    \
-		dqlite__error_close(&h->error);                                     \
-		dqlite__message_close(&h->message);                                 \
-                                                                                    \
-		dqlite__lifecycle_close(DQLITE__LIFECYCLE_ENCODER);                 \
-	}                                                                           \
-                                                                                    \
-	int NAME##_encode(struct NAME *h) {                                         \
-		int err = 0;                                                        \
-                                                                                    \
-		assert(h != NULL);                                                  \
-                                                                                    \
-		dqlite__message_header_put(&h->message, h->type, h->flags);         \
-                                                                                    \
-		switch (h->type) {                                                  \
-			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_PUT, );                \
-                                                                                    \
-		default:                                                            \
-			dqlite__error_printf(                                       \
-			    &h->error, "unknown message type %d", h->type);         \
-			err = DQLITE_PROTO;                                         \
-			goto out;                                                   \
-		}                                                                   \
-                                                                                    \
-		if (err != 0) {                                                     \
-			dqlite__error_wrapf(                                        \
-			    &h->error, &h->message.error, "encode error");          \
-			goto out;                                                   \
-		}                                                                   \
-                                                                                    \
-	out:                                                                        \
-		/* Always invoke the custom resetter if set. */                     \
-		if (h->xReset != NULL) {                                            \
-			h->xReset(h);                                               \
-		}                                                                   \
-                                                                                    \
-		return err;                                                         \
-	}                                                                           \
-                                                                                    \
-	int NAME##_decode(struct NAME *h) {                                         \
-		int err;                                                            \
-                                                                                    \
-		assert(h != NULL);                                                  \
-                                                                                    \
-		h->type = h->message.type;                                          \
-                                                                                    \
-		switch (h->type) {                                                  \
-			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_GET, );                \
-		default:                                                            \
-			dqlite__error_printf(                                       \
-			    &h->error, "unknown message type %d", h->type);         \
-			return DQLITE_PROTO;                                        \
-		}                                                                   \
-                                                                                    \
-		return 0;                                                           \
+#define DQLITE__SCHEMA_HANDLER_IMPLEMENT(NAME, TYPES)                          \
+                                                                               \
+	void NAME##_init(struct NAME *h) {                                     \
+		assert(h != NULL);                                             \
+                                                                               \
+		h->type  = 0;                                                  \
+		h->flags = 0;                                                  \
+                                                                               \
+		dqlite__message_init(&h->message);                             \
+		dqlite__error_init(&h->error);                                 \
+                                                                               \
+		dqlite__lifecycle_init(DQLITE__LIFECYCLE_ENCODER);             \
+	};                                                                     \
+                                                                               \
+	void NAME##_close(struct NAME *h) {                                    \
+		assert(h != NULL);                                             \
+                                                                               \
+		dqlite__error_close(&h->error);                                \
+		dqlite__message_close(&h->message);                            \
+                                                                               \
+		dqlite__lifecycle_close(DQLITE__LIFECYCLE_ENCODER);            \
+	}                                                                      \
+                                                                               \
+	int NAME##_encode(struct NAME *h) {                                    \
+		int err = 0;                                                   \
+                                                                               \
+		assert(h != NULL);                                             \
+                                                                               \
+		dqlite__message_header_put(&h->message, h->type, h->flags);    \
+                                                                               \
+		switch (h->type) {                                             \
+			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_PUT, );           \
+                                                                               \
+		default:                                                       \
+			dqlite__error_printf(                                  \
+			    &h->error, "unknown message type %d", h->type);    \
+			err = DQLITE_PROTO;                                    \
+			goto out;                                              \
+		}                                                              \
+                                                                               \
+		if (err != 0) {                                                \
+			dqlite__error_wrapf(                                   \
+			    &h->error, &h->message.error, "encode error");     \
+			goto out;                                              \
+		}                                                              \
+                                                                               \
+	out:                                                                   \
+		return err;                                                    \
+	}                                                                      \
+                                                                               \
+	int NAME##_decode(struct NAME *h) {                                    \
+		int err;                                                       \
+                                                                               \
+		assert(h != NULL);                                             \
+                                                                               \
+		h->type = h->message.type;                                     \
+                                                                               \
+		switch (h->type) {                                             \
+			TYPES(__DQLITE__SCHEMA_HANDLER_FIELD_GET, );           \
+		default:                                                       \
+			dqlite__error_printf(                                  \
+			    &h->error, "unknown message type %d", h->type);    \
+			return DQLITE_PROTO;                                   \
+		}                                                              \
+                                                                               \
+		return 0;                                                      \
 	}
 
 #endif /* DQLITE_SCHEMA_H */

--- a/test/case.c
+++ b/test/case.c
@@ -17,7 +17,7 @@
 static void test__case_sqlite_log(void *ctx, int rc, const char *errmsg) {
 	(void)ctx;
 
-	munit_errorf("SQLite error: %s (%d)", errmsg, rc);
+	munit_logf(MUNIT_LOG_INFO, "SQLite error: %s (%d)", errmsg, rc);
 }
 
 /* Ensure that SQLite is unconfigured and set test-specific options. */


### PR DESCRIPTION
This is in preparation of non-blocking write requests that need to go through
raft.