### PR TITLE
Split large result queries in multiple responses

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,21 +1,33 @@
-Language: Cpp
-#BasedOnStyle: WebKit
-#AlignAfterOpenBracket: true
+BasedOnStyle: LLVM
+
+AlignTrailingComments: true
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Right
-#AlignOperands: true
-AlignTrailingComments: true
+AlignOperands: true
+
+AllowShortIfStatementsOnASingleLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
-AlwaysBreakAfterReturnType: None
-PenaltyReturnTypeOnItsOwnLine: 100000
+
 BinPackArguments: false
 BinPackParameters: false
-#BreakBeforeBinaryOperators: None
+
+BreakBeforeBraces: Linux
+IndentCaseLabels: false
 IndentWidth: 8
-#PointerAlignment: Right
-#SpacesInContainerLiterals: false
+
 UseTab: ForIndentation
+
+# AfterFunction: true
+#AlignAfterOpenBracket: true
+#AlignEscapedNewlines: Right
+#AllowShortBlocksOnASingleLine: false
+#AlwaysBreakAfterReturnType: None
+#BasedOnStyle: WebKit
+#BraceWrapping:
+#BreakBeforeBinaryOperators: None
+#BreakBeforeBraces: Custom
+#ColumnLimit: 80
+#Language: Cpp
+#PenaltyReturnTypeOnItsOwnLine: 100000
+#SpacesInContainerLiterals: false
 #TabWidth: 8
-ColumnLimit: 80

--- a/include/dqlite.h
+++ b/include/dqlite.h
@@ -68,8 +68,11 @@
 #define DQLITE_CONFIG_CHECKPOINT_THRESHOLD 5
 #define DQLITE_CONFIG_METRICS 6
 
-/* TODO: avoid this redundant EOF marker */
-#define DQLITE_RESPONSE_ROWS_EOF 0xffffffffffffffff
+/* Special value indicating that a batch of rows is over, but there are more. */
+#define DQLITE_RESPONSE_ROWS_PART 0xeeeeeeeeeeeeeeee
+
+/* Special value indicating that the result set is complete. */
+#define DQLITE_RESPONSE_ROWS_DONE 0xffffffffffffffff
 
 /* Initialize SQLite global state with values specific to dqlite
  *

--- a/src/conn.c
+++ b/src/conn.c
@@ -35,7 +35,8 @@ static void dqlite__conn_write_cb(uv_write_t *, int);
 
 /* Write out a response for the client */
 static int dqlite__conn_write(struct dqlite__conn *    c,
-                              struct dqlite__response *response) {
+                              struct dqlite__response *response)
+{
 	int                            err;
 	struct dqlite__conn_write_ctx *ctx;
 	uv_write_t *                   req;
@@ -77,7 +78,8 @@ static int dqlite__conn_write(struct dqlite__conn *    c,
 }
 
 /* Write out a failure response. */
-static int dqlite__conn_write_failure(struct dqlite__conn *c, int code) {
+static int dqlite__conn_write_failure(struct dqlite__conn *c, int code)
+{
 	int err;
 
 	assert(c != NULL);
@@ -112,7 +114,8 @@ static int dqlite__conn_write_failure(struct dqlite__conn *c, int code) {
 	return 0;
 }
 
-static void dqlite__conn_write_cb(uv_write_t *req, int status) {
+static void dqlite__conn_write_cb(uv_write_t *req, int status)
+{
 	struct dqlite__conn_write_ctx *ctx;
 	struct dqlite__conn *          c;
 	struct dqlite__response *      response;
@@ -162,8 +165,8 @@ static void dqlite__conn_write_cb(uv_write_t *req, int status) {
 
 /* Invoked by the gateway when a response for a request is ready to be flushed
  * and sent to the client. */
-static void dqlite__conn_flush_cb(void *                   arg,
-                                  struct dqlite__response *response) {
+static void dqlite__conn_flush_cb(void *arg, struct dqlite__response *response)
+{
 	struct dqlite__conn *c;
 	int                  rc;
 
@@ -206,7 +209,8 @@ response_failure:
  * request. 2) Reqest body: the body of the request is read.
  *
  * After 2) the state machine goes back to 1). */
-static void dqlite__conn_buf_init(struct dqlite__conn *c, uv_buf_t *buf) {
+static void dqlite__conn_buf_init(struct dqlite__conn *c, uv_buf_t *buf)
+{
 	assert(c != NULL);
 	assert(buf->base != NULL);
 	assert(buf->len > 0);
@@ -220,7 +224,8 @@ static void dqlite__conn_buf_init(struct dqlite__conn *c, uv_buf_t *buf) {
 /* Reset the connection read buffer. This should be called at the end of a read
  * phase, to signal that the FSM should be advanced and next phase should
  * start (this is done by dqlite__conn_alloc_cb). */
-static void dqlite__conn_buf_close(struct dqlite__conn *c) {
+static void dqlite__conn_buf_close(struct dqlite__conn *c)
+{
 	assert(c != NULL);
 	assert(c->buf.base != NULL);
 	assert(c->buf.len == 0);
@@ -248,7 +253,8 @@ static struct dqlite__fsm_event dqlite__conn_events[] = {
     {DQLITE__FSM_NULL, NULL},
 };
 
-static int dqlite__conn_handshake_alloc_cb(void *arg) {
+static int dqlite__conn_handshake_alloc_cb(void *arg)
+{
 	struct dqlite__conn *c;
 	uv_buf_t             buf;
 
@@ -266,7 +272,8 @@ static int dqlite__conn_handshake_alloc_cb(void *arg) {
 	return 0;
 }
 
-static int dqlite__conn_handshake_read_cb(void *arg) {
+static int dqlite__conn_handshake_read_cb(void *arg)
+{
 	int                  err;
 	struct dqlite__conn *c;
 
@@ -296,7 +303,8 @@ static struct dqlite__fsm_transition dqlite__conn_transitions_handshake[] = {
     {DQLITE__CONN_READ, dqlite__conn_handshake_read_cb, DQLITE__CONN_HEADER},
 };
 
-static int dqlite__conn_header_alloc_cb(void *arg) {
+static int dqlite__conn_header_alloc_cb(void *arg)
+{
 	struct dqlite__conn *c;
 	uv_buf_t             buf;
 
@@ -316,7 +324,8 @@ static int dqlite__conn_header_alloc_cb(void *arg) {
 	return 0;
 }
 
-static int dqlite__conn_header_read_cb(void *arg) {
+static int dqlite__conn_header_read_cb(void *arg)
+{
 	int                  err;
 	struct dqlite__conn *c;
 
@@ -364,7 +373,8 @@ static struct dqlite__fsm_transition dqlite__conn_transitions_header[] = {
     {DQLITE__CONN_READ, dqlite__conn_header_read_cb, DQLITE__CONN_BODY},
 };
 
-static int dqlite__conn_body_alloc_cb(void *arg) {
+static int dqlite__conn_body_alloc_cb(void *arg)
+{
 	int                  err;
 	struct dqlite__conn *c;
 	uv_buf_t             buf;
@@ -386,7 +396,8 @@ static int dqlite__conn_body_alloc_cb(void *arg) {
 	return 0;
 }
 
-static int dqlite__conn_body_read_cb(void *arg) {
+static int dqlite__conn_body_read_cb(void *arg)
+{
 	int                  err;
 	struct dqlite__conn *c;
 
@@ -437,9 +448,8 @@ static struct dqlite__fsm_transition *dqlite__transitions[] = {
 };
 
 /* Called to allocate a buffer for the next stream read. */
-static void dqlite__conn_alloc_cb(uv_handle_t *stream,
-                                  size_t       _,
-                                  uv_buf_t *   buf) {
+static void dqlite__conn_alloc_cb(uv_handle_t *stream, size_t _, uv_buf_t *buf)
+{
 	int                  err;
 	struct dqlite__conn *c;
 
@@ -473,7 +483,8 @@ static void dqlite__conn_alloc_cb(uv_handle_t *stream,
 	*buf = c->buf;
 }
 
-static void dqlite__conn_alive_cb(uv_timer_t *alive) {
+static void dqlite__conn_alive_cb(uv_timer_t *alive)
+{
 	uint64_t             elapsed;
 	struct dqlite__conn *c;
 
@@ -493,9 +504,9 @@ static void dqlite__conn_alive_cb(uv_timer_t *alive) {
 	}
 }
 
-static void dqlite__conn_read_cb(uv_stream_t *   stream,
-                                 ssize_t         nread,
-                                 const uv_buf_t *buf) {
+static void
+dqlite__conn_read_cb(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
+{
 	int                  err;
 	struct dqlite__conn *c;
 
@@ -562,7 +573,8 @@ void dqlite__conn_init(struct dqlite__conn *   c,
                        dqlite_cluster *        cluster,
                        uv_loop_t *             loop,
                        struct dqlite__options *options,
-                       struct dqlite__metrics *metrics) {
+                       struct dqlite__metrics *metrics)
+{
 	struct dqlite__gateway_cbs callbacks;
 
 	assert(c != NULL);
@@ -607,7 +619,8 @@ void dqlite__conn_init(struct dqlite__conn *   c,
 	c->paused   = 0;
 }
 
-void dqlite__conn_close(struct dqlite__conn *c) {
+void dqlite__conn_close(struct dqlite__conn *c)
+{
 	assert(c != NULL);
 
 	dqlite__response_close(&c->response);
@@ -619,7 +632,8 @@ void dqlite__conn_close(struct dqlite__conn *c) {
 	dqlite__lifecycle_close(DQLITE__LIFECYCLE_CONN);
 }
 
-int dqlite__conn_start(struct dqlite__conn *c) {
+int dqlite__conn_start(struct dqlite__conn *c)
+{
 	int      err;
 	uint64_t heartbeat_timeout;
 
@@ -721,7 +735,8 @@ err:
 	return err;
 }
 
-static void dqlite__conn_stream_close_cb(uv_handle_t *handle) {
+static void dqlite__conn_stream_close_cb(uv_handle_t *handle)
+{
 	struct dqlite__conn *c;
 
 	assert(handle != NULL);
@@ -732,7 +747,8 @@ static void dqlite__conn_stream_close_cb(uv_handle_t *handle) {
 	sqlite3_free(c);
 }
 
-static void dqlite__conn_timer_close_cb(uv_handle_t *handle) {
+static void dqlite__conn_timer_close_cb(uv_handle_t *handle)
+{
 	struct dqlite__conn *c;
 
 	assert(handle != NULL);
@@ -744,7 +760,8 @@ static void dqlite__conn_timer_close_cb(uv_handle_t *handle) {
 
 /* Abort the connection, realeasing any memory allocated by the read buffer, and
  * closing the UV handle (which closes the underlying socket as well) */
-void dqlite__conn_abort(struct dqlite__conn *c) {
+void dqlite__conn_abort(struct dqlite__conn *c)
+{
 	const char *state;
 
 	assert(c != NULL);

--- a/src/conn.h
+++ b/src/conn.h
@@ -33,13 +33,12 @@ struct dqlite__conn {
 	uint64_t      protocol; /* Protocol version */
 
 	/* private */
-	struct dqlite__metrics *metrics; /* Operational metrics */
-	struct dqlite__options *options; /* Connection state machine */
-	struct dqlite__fsm      fsm;     /* Connection state machine */
-	struct dqlite__gateway  gateway; /* Client state and request handler */
-	struct dqlite__request  request; /* Incoming request */
-	struct dqlite__response
-	    response; /* Response buffer for internal failures */
+	struct dqlite__metrics *metrics;  /* Operational metrics */
+	struct dqlite__options *options;  /* Connection state machine */
+	struct dqlite__fsm      fsm;      /* Connection state machine */
+	struct dqlite__gateway  gateway;  /* Client state and request handler */
+	struct dqlite__request  request;  /* Incoming request */
+	struct dqlite__response response; /* Response for internal failures */
 
 	int        fd;   /* File descriptor of client stream */
 	uv_loop_t *loop; /* UV loop */

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -26,6 +26,7 @@
 struct dqlite__gateway_ctx {
 	struct dqlite__request *request;
 	struct dqlite__response response;
+	struct dqlite__stmt *   stmt; /* For multi-response queries */
 };
 
 /* Callbacks that the gateway will invoke during the various phases of request

--- a/src/message.c
+++ b/src/message.c
@@ -19,7 +19,8 @@
 #error "Requires IEEE 754 floating point!"
 #endif
 
-static void dqlite__message_reset(struct dqlite__message *m) {
+static void dqlite__message_reset(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	m->type       = 0;
@@ -32,7 +33,8 @@ static void dqlite__message_reset(struct dqlite__message *m) {
 	m->offset2    = 0;
 }
 
-void dqlite__message_init(struct dqlite__message *m) {
+void dqlite__message_init(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	/* The statically allocated buffer is aligned to word boundary */
@@ -47,7 +49,8 @@ void dqlite__message_init(struct dqlite__message *m) {
 	dqlite__error_init(&m->error);
 }
 
-void dqlite__message_close(struct dqlite__message *m) {
+void dqlite__message_close(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	dqlite__error_close(&m->error);
@@ -59,7 +62,8 @@ void dqlite__message_close(struct dqlite__message *m) {
 	dqlite__lifecycle_close(DQLITE__LIFECYCLE_MESSAGE);
 }
 
-void dqlite__message_header_recv_start(struct dqlite__message *m, uv_buf_t *buf) {
+void dqlite__message_header_recv_start(struct dqlite__message *m, uv_buf_t *buf)
+{
 	assert(m != NULL);
 	assert(buf != NULL);
 
@@ -71,7 +75,8 @@ void dqlite__message_header_recv_start(struct dqlite__message *m, uv_buf_t *buf)
 	buf->len = DQLITE__MESSAGE_HEADER_LEN;
 }
 
-int dqlite__message_header_recv_done(struct dqlite__message *m) {
+int dqlite__message_header_recv_done(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	assert(m->body2.base == NULL);
@@ -91,7 +96,8 @@ int dqlite__message_header_recv_done(struct dqlite__message *m) {
 	return 0;
 }
 
-static size_t dqlite__message_body_len(struct dqlite__message *m) {
+static size_t dqlite__message_body_len(struct dqlite__message *m)
+{
 	assert(m != NULL);
 	assert(m->words > 0);
 
@@ -102,7 +108,8 @@ static size_t dqlite__message_body_len(struct dqlite__message *m) {
 
 /* Allocate the message body dynamic buffer. Used for reading or writing a
  * message body that is larger than the size of the static buffer. */
-static int dqlite__message_body_alloc(struct dqlite__message *m) {
+static int dqlite__message_body_alloc(struct dqlite__message *m)
+{
 	size_t len;
 	assert(m != NULL);
 
@@ -124,7 +131,8 @@ static int dqlite__message_body_alloc(struct dqlite__message *m) {
 	return 0;
 }
 
-int dqlite__message_body_recv_start(struct dqlite__message *m, uv_buf_t *buf) {
+int dqlite__message_body_recv_start(struct dqlite__message *m, uv_buf_t *buf)
+{
 	int err;
 
 	assert(m != NULL);
@@ -153,7 +161,8 @@ int dqlite__message_body_recv_start(struct dqlite__message *m, uv_buf_t *buf) {
 /* Return true if the current read or write offset is aligned to the given
  * quantity. */
 static int dqlite__message_body_is_offset_aligned(struct dqlite__message *m,
-                                                  size_t                  len) {
+                                                  size_t                  len)
+{
 	int align; /* Expected offset alignment */
 
 	assert(m != NULL);
@@ -171,7 +180,8 @@ static int dqlite__message_body_is_offset_aligned(struct dqlite__message *m,
 }
 
 static int
-dqlite__message_get(struct dqlite__message *m, const char **dst, size_t len) {
+dqlite__message_get(struct dqlite__message *m, const char **dst, size_t len)
+{
 	size_t   offset; /* New offset */
 	char *   src;    /* Read buffer */
 	size_t   cap;    /* Size of the read buffer */
@@ -228,7 +238,8 @@ dqlite__message_get(struct dqlite__message *m, const char **dst, size_t len) {
 	return 0;
 }
 
-int dqlite__message_body_get_text(struct dqlite__message *m, text_t *text) {
+int dqlite__message_body_get_text(struct dqlite__message *m, text_t *text)
+{
 	char * src;
 	size_t offset;
 	size_t cap;
@@ -262,13 +273,16 @@ int dqlite__message_body_get_text(struct dqlite__message *m, text_t *text) {
 
 	/* Account for padding */
 	if ((len % DQLITE__MESSAGE_WORD_SIZE) != 0) {
-		len += DQLITE__MESSAGE_WORD_SIZE - (len % DQLITE__MESSAGE_WORD_SIZE);
+		len += DQLITE__MESSAGE_WORD_SIZE -
+		       (len % DQLITE__MESSAGE_WORD_SIZE);
 	}
 
 	return dqlite__message_get(m, text, len);
 }
 
-int dqlite__message_body_get_servers(struct dqlite__message *m, servers_t *servers) {
+int dqlite__message_body_get_servers(struct dqlite__message *m,
+                                     servers_t *             servers)
+{
 	int      err;
 	size_t   i = 0;
 	uint64_t id;
@@ -282,7 +296,8 @@ int dqlite__message_body_get_servers(struct dqlite__message *m, servers_t *serve
 	do {
 		err = dqlite__message_body_get_uint64(m, &id);
 		if (err != 0) {
-			dqlite__error_printf(&m->error, "missing server address");
+			dqlite__error_printf(&m->error,
+			                     "missing server address");
 			err = DQLITE_PROTO;
 			break;
 		}
@@ -297,8 +312,9 @@ int dqlite__message_body_get_servers(struct dqlite__message *m, servers_t *serve
 				if (*servers != NULL) {
 					sqlite3_free(*servers);
 				}
-				dqlite__error_oom(&m->error,
-				                  "failed to allocate servers list");
+				dqlite__error_oom(
+				    &m->error,
+				    "failed to allocate servers list");
 				return DQLITE_NOMEM;
 			}
 			new_servers[i - 1].id      = id;
@@ -312,7 +328,8 @@ int dqlite__message_body_get_servers(struct dqlite__message *m, servers_t *serve
 	return err;
 }
 
-int dqlite__message_body_get_uint8(struct dqlite__message *m, uint8_t *value) {
+int dqlite__message_body_get_uint8(struct dqlite__message *m, uint8_t *value)
+{
 	int err;
 
 	const char *buf;
@@ -330,7 +347,8 @@ int dqlite__message_body_get_uint8(struct dqlite__message *m, uint8_t *value) {
 	return err;
 }
 
-int dqlite__message_body_get_uint32(struct dqlite__message *m, uint32_t *value) {
+int dqlite__message_body_get_uint32(struct dqlite__message *m, uint32_t *value)
+{
 	int err;
 
 	const char *buf;
@@ -348,7 +366,8 @@ int dqlite__message_body_get_uint32(struct dqlite__message *m, uint32_t *value) 
 	return err;
 }
 
-int dqlite__message_body_get_uint64(struct dqlite__message *m, uint64_t *value) {
+int dqlite__message_body_get_uint64(struct dqlite__message *m, uint64_t *value)
+{
 	int         err;
 	const char *buf;
 
@@ -365,11 +384,13 @@ int dqlite__message_body_get_uint64(struct dqlite__message *m, uint64_t *value) 
 	return err;
 }
 
-int dqlite__message_body_get_int64(struct dqlite__message *m, int64_t *value) {
+int dqlite__message_body_get_int64(struct dqlite__message *m, int64_t *value)
+{
 	return dqlite__message_body_get_uint64(m, (uint64_t *)value);
 }
 
-int dqlite__message_body_get_double(struct dqlite__message *m, double_t *value) {
+int dqlite__message_body_get_double(struct dqlite__message *m, double_t *value)
+{
 	int         err;
 	const char *buf;
 
@@ -388,7 +409,8 @@ int dqlite__message_body_get_double(struct dqlite__message *m, double_t *value) 
 
 void dqlite__message_header_put(struct dqlite__message *m,
                                 uint8_t                 type,
-                                uint8_t                 flags) {
+                                uint8_t                 flags)
+{
 	assert(m != NULL);
 
 	m->type  = type;
@@ -398,7 +420,8 @@ void dqlite__message_header_put(struct dqlite__message *m,
 static int dqlite__message_body_put(struct dqlite__message *m,
                                     const char *            src,
                                     size_t                  len,
-                                    size_t                  pad) {
+                                    size_t                  pad)
+{
 	size_t offset; /* Write offset */
 	char * dst;    /* Write buffer to use */
 
@@ -433,8 +456,9 @@ static int dqlite__message_body_put(struct dqlite__message *m,
 			cap  = m->offset2 + len + pad + 1024;
 			base = sqlite3_realloc(m->body2.base, cap);
 			if (base == NULL) {
-				dqlite__error_oom(&m->error,
-				                  "failed to allocate dynamic body");
+				dqlite__error_oom(
+				    &m->error,
+				    "failed to allocate dynamic body");
 				return DQLITE_NOMEM;
 			}
 			m->body2.base = base;
@@ -464,7 +488,8 @@ static int dqlite__message_body_put(struct dqlite__message *m,
 	return 0;
 }
 
-int dqlite__message_body_put_text(struct dqlite__message *m, text_t text) {
+int dqlite__message_body_put_text(struct dqlite__message *m, text_t text)
+{
 	size_t pad;
 	size_t len;
 
@@ -483,7 +508,9 @@ int dqlite__message_body_put_text(struct dqlite__message *m, text_t text) {
 	return dqlite__message_body_put(m, text, len, pad);
 }
 
-int dqlite__message_body_put_servers(struct dqlite__message *m, servers_t servers) {
+int dqlite__message_body_put_servers(struct dqlite__message *m,
+                                     servers_t               servers)
+{
 	int    err;
 	size_t i;
 
@@ -505,31 +532,39 @@ int dqlite__message_body_put_servers(struct dqlite__message *m, servers_t server
 	return 0;
 }
 
-int dqlite__message_body_put_uint8(struct dqlite__message *m, uint8_t value) {
+int dqlite__message_body_put_uint8(struct dqlite__message *m, uint8_t value)
+{
 	assert(m != NULL);
 
-	return dqlite__message_body_put(m, (const char *)(&value), sizeof(value), 0);
+	return dqlite__message_body_put(
+	    m, (const char *)(&value), sizeof(value), 0);
 }
 
-int dqlite__message_body_put_uint32(struct dqlite__message *m, uint32_t value) {
+int dqlite__message_body_put_uint32(struct dqlite__message *m, uint32_t value)
+{
 	assert(m != NULL);
 
 	value = dqlite__flip32(value);
-	return dqlite__message_body_put(m, (const char *)(&value), sizeof(value), 0);
+	return dqlite__message_body_put(
+	    m, (const char *)(&value), sizeof(value), 0);
 }
 
-int dqlite__message_body_put_uint64(struct dqlite__message *m, uint64_t value) {
+int dqlite__message_body_put_uint64(struct dqlite__message *m, uint64_t value)
+{
 	assert(m != NULL);
 
 	value = dqlite__flip64(value);
-	return dqlite__message_body_put(m, (const char *)(&value), sizeof(value), 0);
+	return dqlite__message_body_put(
+	    m, (const char *)(&value), sizeof(value), 0);
 }
 
-int dqlite__message_body_put_int64(struct dqlite__message *m, int64_t value) {
+int dqlite__message_body_put_int64(struct dqlite__message *m, int64_t value)
+{
 	return dqlite__message_body_put_uint64(m, (uint64_t)value);
 }
 
-int dqlite__message_body_put_double(struct dqlite__message *m, double_t value) {
+int dqlite__message_body_put_double(struct dqlite__message *m, double_t value)
+{
 	uint64_t buf;
 
 	assert(m != NULL);
@@ -544,10 +579,12 @@ int dqlite__message_body_put_double(struct dqlite__message *m, double_t value) {
 
 	buf = dqlite__flip64(buf);
 
-	return dqlite__message_body_put(m, (const char *)(&buf), sizeof(buf), 0);
+	return dqlite__message_body_put(
+	    m, (const char *)(&buf), sizeof(buf), 0);
 }
 
-void dqlite__message_send_start(struct dqlite__message *m, uv_buf_t bufs[3]) {
+void dqlite__message_send_start(struct dqlite__message *m, uv_buf_t bufs[3])
+{
 	assert(m != NULL);
 	assert(bufs != NULL);
 
@@ -561,8 +598,8 @@ void dqlite__message_send_start(struct dqlite__message *m, uv_buf_t bufs[3]) {
 	assert((m->offset1 % DQLITE__MESSAGE_WORD_SIZE) == 0);
 	assert((m->offset2 % DQLITE__MESSAGE_WORD_SIZE) == 0);
 
-	m->words =
-	    dqlite__flip32((m->offset1 + m->offset2) / DQLITE__MESSAGE_WORD_SIZE);
+	m->words = dqlite__flip32((m->offset1 + m->offset2) /
+	                          DQLITE__MESSAGE_WORD_SIZE);
 
 	/* The message header is stored in the first part of the dqlite_message
 	 * structure. */
@@ -580,7 +617,8 @@ void dqlite__message_send_start(struct dqlite__message *m, uv_buf_t bufs[3]) {
 	return;
 }
 
-void dqlite__message_send_reset(struct dqlite__message *m) {
+void dqlite__message_send_reset(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	/* Reset the state so we can start writing another message */
@@ -590,7 +628,8 @@ void dqlite__message_send_reset(struct dqlite__message *m) {
 	dqlite__message_reset(m);
 }
 
-void dqlite__message_recv_reset(struct dqlite__message *m) {
+void dqlite__message_recv_reset(struct dqlite__message *m)
+{
 	assert(m != NULL);
 
 	/* This must come after the header has been received */
@@ -601,4 +640,29 @@ void dqlite__message_recv_reset(struct dqlite__message *m) {
 		sqlite3_free(m->body2.base);
 	}
 	dqlite__message_reset(m);
+}
+
+int dqlite__message_has_been_fully_consumed(struct dqlite__message *m)
+{
+	size_t offset;
+	size_t words;
+
+	assert(m != NULL);
+
+	if (m->body2.base != NULL) {
+		offset = m->offset2;
+	} else {
+		offset = m->offset1;
+	}
+
+	words = offset / DQLITE__MESSAGE_WORD_SIZE;
+
+	return words == m->words;
+}
+
+int dqlite__message_is_large(struct dqlite__message *m)
+{
+	assert(m != NULL);
+
+	return m->body2.base != NULL;
 }

--- a/src/message.h
+++ b/src/message.h
@@ -43,7 +43,7 @@
 
 /* Number of words that the statically allocated message body buffer can
  * hold. */
-#define DQLITE__MESSAGE_BUF_WORDS                                                   \
+#define DQLITE__MESSAGE_BUF_WORDS                                              \
 	(DQLITE__MESSAGE_BUF_LEN / DQLITE__MESSAGE_WORD_SIZE)
 
 /* The maximum number of statement bindings or column rows is 255, which can fit
@@ -59,7 +59,8 @@ typedef dqlite_server_info *servers_t;
 /* We rely on the size of double to be 64 bit, since that's what sent over the
  * wire. */
 #ifdef static_assert
-static_assert(sizeof(double) == sizeof(uint64_t), "Size of 'double' is not 64 bits");
+static_assert(sizeof(double) == sizeof(uint64_t),
+              "Size of 'double' is not 64 bits");
 #endif
 
 /* A message serializes dqlite requests and responses. */
@@ -79,9 +80,9 @@ struct dqlite__message {
 		char     body1[DQLITE__MESSAGE_BUF_LEN];
 		uint64_t __body1__[DQLITE__MESSAGE_BUF_WORDS]; /* Alignment */
 	};
-	uv_buf_t body2; /* Dynamically allocated buffer for bodies exeeding body1 */
-	size_t offset1; /* Number of bytes that have been read or written to body1 */
-	size_t offset2; /* Number of bytes that have been read or written to bdoy2 */
+	uv_buf_t body2;   /* Dynamic buffer for bodies exceeding body1 */
+	size_t   offset1; /* Bytes that have been read or written to body1 */
+	size_t   offset2; /* Bytes that have been read or written to bdoy2 */
 };
 
 /* Initialize the message. */
@@ -95,7 +96,8 @@ void dqlite__message_close(struct dqlite__message *m);
  * It returns a buffer large enough to hold the message header bytes. The buffer
  * must be progressivelly filled with the received data as it gets received from
  * the client, until it's full. */
-void dqlite__message_header_recv_start(struct dqlite__message *m, uv_buf_t *buf);
+void dqlite__message_header_recv_start(struct dqlite__message *m,
+                                       uv_buf_t *              buf);
 
 /* Called when the buffer returned by dqlite__message_header_recv_start has been
  * completely filled by reads and the header is complete.
@@ -122,7 +124,8 @@ int dqlite__message_body_get_uint32(struct dqlite__message *m, uint32_t *value);
 int dqlite__message_body_get_uint64(struct dqlite__message *m, uint64_t *value);
 int dqlite__message_body_get_int64(struct dqlite__message *m, int64_t *value);
 int dqlite__message_body_get_double(struct dqlite__message *m, double_t *value);
-int dqlite__message_body_get_servers(struct dqlite__message *m, servers_t *servers);
+int dqlite__message_body_get_servers(struct dqlite__message *m,
+                                     servers_t *             servers);
 
 /* Called after the message body has been completely decoded and it has been
  * processed. It resets the internal state so the object can be re-used for
@@ -143,7 +146,8 @@ int dqlite__message_body_put_uint32(struct dqlite__message *m, uint32_t value);
 int dqlite__message_body_put_int64(struct dqlite__message *m, int64_t value);
 int dqlite__message_body_put_uint64(struct dqlite__message *m, uint64_t value);
 int dqlite__message_body_put_double(struct dqlite__message *m, double_t value);
-int dqlite__message_body_put_servers(struct dqlite__message *m, servers_t servers);
+int dqlite__message_body_put_servers(struct dqlite__message *m,
+                                     servers_t               servers);
 
 /* Called when starting to send a message.
  *
@@ -157,5 +161,11 @@ void dqlite__message_send_start(struct dqlite__message *m, uv_buf_t bufs[3]);
  * It resets the internal state so the object can be re-used for sending another
  * message. */
 void dqlite__message_send_reset(struct dqlite__message *m);
+
+/* Return true if the message has been completely read. */
+int dqlite__message_has_been_fully_consumed(struct dqlite__message *m);
+
+/* Return true if the message is exceeding the static buffer size. */
+int dqlite__message_is_large(struct dqlite__message *m);
 
 #endif /* DQLITE_MESSAGE_H */

--- a/src/schema.h
+++ b/src/schema.h
@@ -67,7 +67,8 @@
 #define DQLITE__SCHEMA_IMPLEMENT(NAME, SCHEMA)                                 \
                                                                                \
 	int NAME##_put(                                                        \
-	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {     \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e)       \
+	{                                                                      \
 		int err;                                                       \
                                                                                \
 		assert(p != NULL);                                             \
@@ -79,7 +80,8 @@
 	};                                                                     \
                                                                                \
 	int NAME##_get(                                                        \
-	    struct NAME *p, struct dqlite__message *m, dqlite__error *e) {     \
+	    struct NAME *p, struct dqlite__message *m, dqlite__error *e)       \
+	{                                                                      \
 		int err;                                                       \
                                                                                \
 		assert(p != NULL);                                             \
@@ -146,7 +148,8 @@
 /* Implement a new schema handler. */
 #define DQLITE__SCHEMA_HANDLER_IMPLEMENT(NAME, TYPES)                          \
                                                                                \
-	void NAME##_init(struct NAME *h) {                                     \
+	void NAME##_init(struct NAME *h)                                       \
+	{                                                                      \
 		assert(h != NULL);                                             \
                                                                                \
 		h->type  = 0;                                                  \
@@ -158,7 +161,8 @@
 		dqlite__lifecycle_init(DQLITE__LIFECYCLE_ENCODER);             \
 	};                                                                     \
                                                                                \
-	void NAME##_close(struct NAME *h) {                                    \
+	void NAME##_close(struct NAME *h)                                      \
+	{                                                                      \
 		assert(h != NULL);                                             \
                                                                                \
 		dqlite__error_close(&h->error);                                \
@@ -167,7 +171,8 @@
 		dqlite__lifecycle_close(DQLITE__LIFECYCLE_ENCODER);            \
 	}                                                                      \
                                                                                \
-	int NAME##_encode(struct NAME *h) {                                    \
+	int NAME##_encode(struct NAME *h)                                      \
+	{                                                                      \
 		int err = 0;                                                   \
                                                                                \
 		assert(h != NULL);                                             \
@@ -194,7 +199,8 @@
 		return err;                                                    \
 	}                                                                      \
                                                                                \
-	int NAME##_decode(struct NAME *h) {                                    \
+	int NAME##_decode(struct NAME *h)                                      \
+	{                                                                      \
 		int err;                                                       \
                                                                                \
 		assert(h != NULL);                                             \

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -1,3 +1,47 @@
+/******************************************************************************
+ *
+ * APIs to decode parameters and bind them to SQLite statement, and to fetch
+ * rows and encode them.
+ *
+ * The dqlite wire format for a list of parameters to be bound to a statement
+ * is divided in header and body. The format of the header is:
+ *
+ *  8 bits: Number of parameters to bind (min is 1, max is 255).
+ *  4 bits: Type code of the 1st parameter to bind.
+ *  4 bits: Type code of the 2nd parameter to bind, or 0.
+ *  4 bits: Type code of the 3rn parameter to bind, or 0.
+ *  ...
+ *
+ * This repeats until reaching a full 64-bit word. If there are more than 14
+ * parameters, the header will grow additional 64-bit words as needed, following
+ * the same pattern: a sequence of 4-bit slots with type codes of the parameters
+ * to bind, followed by a sequence of zero bits, until word boundary is reached.
+ *
+ * After the parameters header follows the parameters body, which contain one
+ * value for each parameter to bind, following the normal encoding rules.
+ *
+ * The dqlite wire format for a set of query rows is divided in header and
+ * body. The format of the header is:
+ *
+ *  64 bits: Number of columns in the result set (min is 1).
+ *  64 bits: Name of the first column. If the name is longer, additional words
+ *           of 64 bits can be used, like for normal string encoding.
+ *  ...      If present, name of the 2nd, 3rd, ..., nth column.
+ *
+ * After the result set header follows the result set body, which is a sequence
+ * of zero or more rows. Each row has the following format:
+ *
+ *  4 bits: Type code of the 1st column of the row.
+ *  4 bits: Type code of the 2nd column of row, or 0.
+ *  4 bits: Type code of the 2nd column of row, or 0.
+ *
+ * This repeats until reaching a full 64-bit word. If there are more than 16 row
+ * columns, the header will grow additional 64-bit words as needed, following
+ * the same pattern. After this row preamble, the values of all columns of the
+ * row follow, using the normal dqlite enconding conventions.
+ *
+ *****************************************************************************/
+
 #ifndef DQLITE_STMT_H
 #define DQLITE_STMT_H
 
@@ -22,7 +66,8 @@ void dqlite__stmt_init(struct dqlite__stmt *s);
 /* Close a statement state object, releasing all associated resources. */
 void dqlite__stmt_close(struct dqlite__stmt *s);
 
-/* No-op hash function (hashing is not supported for dqlite__stmt). */
+/* No-op hash function (hashing is not supported for dqlite__stmt). This is
+ * required by the registry interface. */
 const char *dqlite__stmt_hash(struct dqlite__stmt *stmt);
 
 /* Bind the parameters of the underlying statement by decoding the given

--- a/test/runner.c
+++ b/test/runner.c
@@ -55,7 +55,8 @@ static MunitSuite dqlite__test_suite = {(char *)"",
                                         0};
 
 /* Test runner executable */
-int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
+int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)])
+{
 	return munit_suite_main(
 	    &dqlite__test_suite, (void *)"µnit", argc, argv);
 }

--- a/test/socket.h
+++ b/test/socket.h
@@ -7,19 +7,25 @@
 #ifndef DQLITE_TEST_SOCKET_H
 #define DQLITE_TEST_SOCKET_H
 
+#include "munit.h"
+
+/* Munit parameter defining the socket type to use in test_socket_pair_setup. */
+#define TEST_SOCKET_PARAM "socket-family"
+
+extern char *test_socket_param_values[];
+
 struct test_socket_pair {
-	int server; /* Server-side file descriptor */
-	int client; /* Client-side file descriptor */
-
-	int client_disconnected; /* Whether the client was disconnected by tests */
-	int server_disconnected; /* Whether the server was disconnected by tests */
-
-	/* Private */
-	int listen; /* Listener file descriptor, for cleanup */
+	int server;              /* Server-side file descriptor */
+	int client;              /* Client-side file descriptor */
+	int server_disconnected; /* If the server was disconnected by tests */
+	int client_disconnected; /* If the client was disconnected by tests */
+	int listen;              /* Listener file descriptor, for cleanup */
 };
 
-void test_socket_pair_init(struct test_socket_pair *p, const char *family);
-void test_socket_pair_close(struct test_socket_pair *p);
+void test_socket_pair_setup(const MunitParameter     params[],
+                            struct test_socket_pair *p);
+
+void test_socket_pair_tear_down(struct test_socket_pair *p);
 
 void test_socket_pair_client_disconnect(struct test_socket_pair *p);
 void test_socket_pair_server_disconnect(struct test_socket_pair *p);

--- a/test/test_conn.c
+++ b/test/test_conn.c
@@ -9,8 +9,8 @@
 #include "../src/metrics.h"
 #include "../src/options.h"
 
+#include "case.h"
 #include "cluster.h"
-#include "leak.h"
 #include "log.h"
 #include "munit.h"
 #include "socket.h"
@@ -23,14 +23,53 @@
 
 struct fixture {
 	struct test_socket_pair sockets;
+	struct dqlite__options  options;
+	struct dqlite__metrics  metrics;
 	uv_loop_t               loop;
 	struct dqlite__conn *   conn;
 	struct dqlite__response response;
-	struct dqlite__options  options;
-	struct dqlite__metrics  metrics;
 };
 
-static void __recv_response(struct fixture *f) {
+/* Run the fixture loop once.
+ *
+ * If expect_more_callbacks is true, then assert that no more callbacks are
+ * expected, otherwise assert that more callbacks are expected. */
+static void __run_loop(struct fixture *f, int expect_more_callbacks)
+{
+	int rc;
+
+	rc = uv_run(&f->loop, UV_RUN_NOWAIT);
+	munit_assert_int(rc, ==, expect_more_callbacks);
+
+	if (!expect_more_callbacks) {
+		/* The server connection should have been closed, since there's
+		 * no more data to process. */
+		f->sockets.server_disconnected = 1;
+	}
+}
+
+/* Send data from the client connection to the server connection.
+ *
+ * Expect all bytes to be written. */
+static void __send_data(struct fixture *f, void *buf, size_t count)
+{
+	int nwrite;
+
+	nwrite = write(f->sockets.client, buf, count);
+	munit_assert_int(nwrite, ==, count);
+}
+
+/* Send a full handshake using the given protocol version. */
+static void __send_handshake(struct fixture *f, uint64_t protocol)
+{
+	uint64_t buf = dqlite__flip64(protocol);
+
+	__send_data(f, &buf, sizeof buf);
+}
+
+/* Receive a full response from the server connection. */
+static void __recv_response(struct fixture *f)
+{
 	int      err;
 	uv_buf_t buf;
 	ssize_t  nread;
@@ -62,10 +101,8 @@ static void __recv_response(struct fixture *f) {
  ******************************************************************************/
 
 /* Run the tests using both TCP and Unix sockets. */
-static char *test_socket_families[] = {"tcp", "unix", NULL};
-
-static MunitParameterEnum test_socket_family_params[] = {
-    {"socket-family", test_socket_families},
+static MunitParameterEnum params[] = {
+    {TEST_SOCKET_PARAM, test_socket_param_values},
     {NULL, NULL},
 };
 
@@ -75,21 +112,16 @@ static MunitParameterEnum test_socket_family_params[] = {
  *
  ******************************************************************************/
 
-static void *setup(const MunitParameter params[], void *user_data) {
-	struct fixture *f;
-	const char *    socket_family;
+static void *setup(const MunitParameter params[], void *user_data)
+{
+	struct fixture *f = munit_malloc(sizeof *f);
 	int             err;
 
-	(void)user_data;
-
-	socket_family = munit_parameters_get(params, "socket-family");
-
-	f = munit_malloc(sizeof *f);
+	test_case_setup(params, user_data);
+	test_socket_pair_setup(params, &f->sockets);
 
 	f->conn = sqlite3_malloc(sizeof *f->conn);
 	munit_assert_ptr_not_null(f->conn);
-
-	test_socket_pair_init(&f->sockets, socket_family);
 
 	err = uv_loop_init(&f->loop);
 	munit_assert_int(err, ==, 0);
@@ -101,17 +133,20 @@ static void *setup(const MunitParameter params[], void *user_data) {
 	                  &f->loop,
 	                  &f->options,
 	                  &f->metrics);
-	f->conn->logger = test_logger();
 
 	dqlite__response_init(&f->response);
 
 	dqlite__options_defaults(&f->options);
 	dqlite__metrics_init(&f->metrics);
 
+	err = dqlite__conn_start(f->conn);
+	munit_assert_int(err, ==, 0);
+
 	return f;
 }
 
-static void tear_down(void *data) {
+static void tear_down(void *data)
+{
 	struct fixture *f = data;
 	int             err;
 
@@ -120,292 +155,189 @@ static void tear_down(void *data) {
 	err = uv_loop_close(&f->loop);
 	munit_assert_int(err, ==, 0);
 
-	test_socket_pair_close(&f->sockets);
-	test_assert_no_leaks();
+	test_socket_pair_tear_down(&f->sockets);
+	test_case_tear_down(data);
 }
 
 /******************************************************************************
  *
- * Tests for dqlite__conn_abort
+ * dqlite__conn_abort
  *
  ******************************************************************************/
 
 static MunitResult test_abort_immediately(const MunitParameter params[],
-                                          void *               data) {
+                                          void *               data)
+{
 	struct fixture *f = data;
-	int             err;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
-
+	/* Drop the client connection immediately. */
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_abort_during_handshake(const MunitParameter params[],
-                                               void *               data) {
+                                               void *               data)
+{
 	struct fixture *f = data;
-	int             err;
 	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	ssize_t         nwrite;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write part of the handshake then drop the client connection. */
+	__send_data(f, &protocol, sizeof protocol - 5);
 
-	nwrite = write(f->sockets.client, &protocol, 3);
-	munit_assert_int(nwrite, ==, 3);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_abort_after_handshake(const MunitParameter params[],
-                                              void *               data) {
+                                              void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	ssize_t         nwrite;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake then drop the client connection. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_abort_during_header(const MunitParameter params[],
-                                            void *               data) {
+                                            void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[7]   = {/* Partial header */
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0};
-	ssize_t         nwrite;
+
+	uint8_t buf[][8] = {
+	    {0, 0, 0, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
+	/* Write only a part of the header then drop the client connection. */
+	__send_data(f, buf, sizeof buf - 1);
 
-	nwrite = write(f->sockets.client, buf, 7);
-	munit_assert_int(nwrite, ==, 7);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_abort_after_header(const MunitParameter params[],
-                                           void *               data) {
+                                           void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[8]   = {/* Full header */
-                          1,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0,
-                          0};
-	ssize_t         nwrite;
+
+	uint8_t buf[][8] = {
+	    {1, 0, 0, 0, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
+	/* Write a full request header then drop the connection. */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 8);
-	munit_assert_int(nwrite, ==, 8);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_abort_during_body(const MunitParameter params[],
-                                          void *               data) {
+                                          void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[13]  = {/* Header and partial body */
-                           1,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0};
-	ssize_t         nwrite;
+
+	uint8_t buf[][8] = {
+	    {1, 0, 0, 0, 0, 0, 0, 0},
+	    {0, 0, 0, 0, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
+	/* Write the header and just a part of the body. */
+	__send_data(f, buf, sizeof buf - 5);
 
-	nwrite = write(f->sockets.client, buf, 13);
-	munit_assert_int(nwrite, ==, 13);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
-static MunitResult test_abort_after_body(const MunitParameter params[], void *data) {
+static MunitResult test_abort_after_body(const MunitParameter params[],
+                                         void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[16]  = {
-            /* Header and body (Leader request) */
-            1,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        };
-	ssize_t nwrite;
+
+	uint8_t buf[][8] = {
+	    {1, 0, 0, 0, 0, 0, 0, 0},
+	    {0, 0, 0, 0, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
+	/* Write a full leader request */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 16);
-	munit_assert_int(nwrite, ==, 16);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
-static MunitResult test_abort_after_heartbeat_timeout(const MunitParameter params[],
-                                                      void *               data) {
+static MunitResult
+test_abort_after_heartbeat_timeout(const MunitParameter params[], void *data)
+{
 	struct fixture *f = data;
-	int             err;
 	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[3]   = {
+	uint8_t         buf[3] = {
             /* Incomplete header */
             0,
             0,
@@ -417,9 +349,6 @@ static MunitResult test_abort_after_heartbeat_timeout(const MunitParameter param
 
 	f->conn->options->heartbeat_timeout = 1; /* Abort after a millisecond */
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
-
 	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
 	munit_assert_int(nwrite, ==, sizeof(protocol));
 
@@ -428,127 +357,76 @@ static MunitResult test_abort_after_heartbeat_timeout(const MunitParameter param
 
 	usleep(2 * 1000);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitTest dqlite__conn_abort_tests[] = {
-    {"/immediately",
-     test_abort_immediately,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
+    {"/immediately", test_abort_immediately, setup, tear_down, 0, params},
     {"/during-handshake",
      test_abort_during_handshake,
      setup,
      tear_down,
      0,
-     test_socket_family_params},
+     params},
     {"/after-handshake",
      test_abort_after_handshake,
      setup,
      tear_down,
      0,
-     test_socket_family_params},
-    {"/during-header",
-     test_abort_during_header,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/after-header",
-     test_abort_after_header,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/during-body",
-     test_abort_during_body,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/after-body",
-     test_abort_after_body,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    //	{"after heartbeat timeout", test_dqlite__conn_abort_after_heartbeat_timeout},
+     params},
+    {"/during-header", test_abort_during_header, setup, tear_down, 0, params},
+    {"/after-header", test_abort_after_header, setup, tear_down, 0, params},
+    {"/during-body", test_abort_during_body, setup, tear_down, 0, params},
+    {"/after-body", test_abort_after_body, setup, tear_down, 0, params},
+    //	{"after heartbeat timeout",
+    // test_dqlite__conn_abort_after_heartbeat_timeout},
     {NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
 };
 
 /******************************************************************************
  *
- * Tests for dqlite__conn_read_cb
+ * dqlite__conn_read_cb
  *
  ******************************************************************************/
 
-static MunitResult test_read_cb_unknown_protocol(const MunitParameter params[],
-                                                 void *               data) {
+static MunitResult test_read_cb_bad_protocol(const MunitParameter params[],
+                                             void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = 0x123456;
-	ssize_t         nwrite;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write an unknonw protocol version. */
+	__send_handshake(f, 0x123456);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof protocol);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0 /* Number of pending handles */);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_read_cb_empty_body(const MunitParameter params[],
-                                           void *               data) {
+                                           void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[8]   = {
-            /* Invalid header (empty body) */
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        };
-	ssize_t nwrite;
+
+	uint8_t buf[][8] = {
+	    {0, 0, 0, 0, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof protocol);
+	__run_loop(f, 1);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	/* Write a header whose body words count field is zero. */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 8);
-	munit_assert_int(nwrite, ==, 8);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	__recv_response(f);
 
@@ -560,51 +438,33 @@ static MunitResult test_read_cb_empty_body(const MunitParameter params[],
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
-static MunitResult test_read_cb_body_too_large(const MunitParameter params[],
-                                               void *               data) {
+static MunitResult test_read_cb_body_too_big(const MunitParameter params[],
+                                             void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[8]   = {
-            /* Invalid header (body too large) */
-            0xf,
-            0xf,
-            0xf,
-            0xf,
-            0,
-            0,
-            0,
-            0,
-        };
-	ssize_t nwrite;
+
+	/* Header indicating a body which is too large */
+	uint8_t buf[][8] = {
+	    {0xf, 0xf, 0xf, 0xf, 0, 0, 0, 0},
+	};
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof protocol);
+	__run_loop(f, 1);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	/* Write a header whose body words count is way to large. */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 8);
-	munit_assert_int(nwrite, ==, 8);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	__recv_response(f);
 
@@ -616,50 +476,34 @@ static MunitResult test_read_cb_body_too_large(const MunitParameter params[],
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
-static MunitResult test_read_cb_malformed_body(const MunitParameter params[],
-                                               void *               data) {
+static MunitResult test_read_cb_bad_body(const MunitParameter params[],
+                                         void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[32]  = {
-            /* Valid header for Open request, invalid Open.volatile */
-            3,   0,   0,   0,   DQLITE_REQUEST_OPEN,
-            0,   0,   0,   't', 'e',
-            's', 't', '.', 'd', 'b',
-            0,   0,   0,   0,   0,
-            0,   0,   0,   0,   'v',
-            'o', 'l', 'a', 't', 'i',
-            'e', 'x',
+	uint8_t         buf[][8] = {
+            {3, 0, 0, 0, DQLITE_REQUEST_OPEN, 0, 0, 0},
+            {'t', 'e', 's', 't', '.', 'd', 'b', 0},
+            {0, 0, 0, 0, 0, 0, 0, 0},
+            {'v', 'o', 'l', 'a', 't', 'i', 'e', 'x'},
         };
-	ssize_t nwrite;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof(protocol));
+	__run_loop(f, 1);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	/* Send a full open request whose vfs name is invalid. */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 32);
-	munit_assert_int(nwrite, ==, 32);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	__recv_response(f);
 
@@ -672,99 +516,93 @@ static MunitResult test_read_cb_malformed_body(const MunitParameter params[],
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
-
-	f->sockets.server_disconnected = 1;
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitResult test_read_cb_invalid_db_id(const MunitParameter params[],
-                                              void *               data) {
+                                              void *               data)
+{
 	struct fixture *f = data;
-	int             err;
-	uint64_t        protocol = dqlite__flip64(DQLITE_PROTOCOL_VERSION);
-	uint8_t         buf[24]  = {
-            /* Valid header for Prepare request, invalid Prepare.db_id */
-            2,   0,   0,   0,   DQLITE_REQUEST_PREPARE,
-            0,   0,   0,   1,   0,
-            0,   0,   0,   0,   0,
-            0,   'S', 'E', 'L', 'E',
-            'C', ' ', '1', 0,
+	uint8_t         buf[][8] = {
+            {2, 0, 0, 0, DQLITE_REQUEST_PREPARE, 0, 0, 0},
+            {1, 0, 0, 0, 0, 0, 0, 0},
+            {'S', 'E', 'L', 'E', 'C', 'T', '1', 0},
         };
-	ssize_t nwrite;
 
 	(void)params;
 
-	err = dqlite__conn_start(f->conn);
-	munit_assert_int(err, ==, 0);
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
 
-	nwrite = write(f->sockets.client, &protocol, sizeof(protocol));
-	munit_assert_int(nwrite, ==, sizeof protocol);
+	__run_loop(f, 1);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	/* Send a full Prepare request with and invalid db_id */
+	__send_data(f, buf, sizeof buf);
 
-	nwrite = write(f->sockets.client, buf, 24);
-	munit_assert_int(nwrite, ==, 24);
-
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
 
 	__recv_response(f);
 
 	munit_assert_int(f->response.type, ==, DQLITE_RESPONSE_FAILURE);
 	munit_assert_int(f->response.failure.code, ==, SQLITE_NOTFOUND);
-	munit_assert_string_equal(f->response.failure.message, "no db with id 1");
+	munit_assert_string_equal(f->response.failure.message,
+	                          "no db with id 1");
 
 	test_socket_pair_client_disconnect(&f->sockets);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 1 /* Number of pending handles */);
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
-	err = uv_run(&f->loop, UV_RUN_NOWAIT);
-	munit_assert_int(err, ==, 0);
+	return MUNIT_OK;
+}
 
-	f->sockets.server_disconnected = 1;
+static MunitResult test_read_cb_throttle(const MunitParameter params[],
+                                         void *               data)
+{
+	struct fixture *f = data;
+	uint8_t         buf[][8] = {
+            {1, 0, 0, 0, 0, 0, 0, 0},
+            {0, 0, 0, 0, 0, 0, 0, 0},
+            {1, 0, 0, 0, 0, 0, 0, 0},
+            {0, 0, 0, 0, 0, 0, 0, 0},
+        };
+
+	(void)params;
+
+	/* Write the handshake. */
+	__send_handshake(f, DQLITE_PROTOCOL_VERSION);
+
+	__run_loop(f, 1);
+
+	/* Send two full consecutive leader requests, without waiting for the
+	 * response first. */
+	__send_data(f, buf, sizeof buf);
+
+	__run_loop(f, 1);
+
+	__recv_response(f);
+	__run_loop(f, 1);
+
+	__recv_response(f);
+
+	test_socket_pair_client_disconnect(&f->sockets);
+
+	__run_loop(f, 1);
+	__run_loop(f, 0);
 
 	return MUNIT_OK;
 }
 
 static MunitTest dqlite__conn_read_cb_tests[] = {
-    {"/unknown-protocol",
-     test_read_cb_unknown_protocol,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/empty-body",
-     test_read_cb_empty_body,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/body-too-large",
-     test_read_cb_body_too_large,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/malformed-body",
-     test_read_cb_malformed_body,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
-    {"/invalid-db-id",
-     test_read_cb_invalid_db_id,
-     setup,
-     tear_down,
-     0,
-     test_socket_family_params},
+    {"/bad-protocol", test_read_cb_bad_protocol, setup, tear_down, 0, params},
+    {"/empty-body", test_read_cb_empty_body, setup, tear_down, 0, params},
+    {"/body-too-big", test_read_cb_body_too_big, setup, tear_down, 0, params},
+    {"/bad-body", test_read_cb_bad_body, setup, tear_down, 0, params},
+    {"/invalid-db-id", test_read_cb_invalid_db_id, setup, tear_down, 0, params},
+    {"/throttle", test_read_cb_throttle, setup, tear_down, 0, params},
     {NULL, NULL, NULL, NULL, 0, NULL},
 };
 
@@ -775,7 +613,7 @@ static MunitTest dqlite__conn_read_cb_tests[] = {
  ******************************************************************************/
 
 MunitSuite dqlite__conn_suites[] = {
-    {"_abort", dqlite__conn_abort_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE},
-    {"_read_cb", dqlite__conn_read_cb_tests, NULL, 1, MUNIT_SUITE_OPTION_NONE},
-    {NULL, NULL, NULL, 0, MUNIT_SUITE_OPTION_NONE},
+    {"_abort", dqlite__conn_abort_tests, NULL, 1, 0},
+    {"_read_cb", dqlite__conn_read_cb_tests, NULL, 1, 0},
+    {NULL, NULL, NULL, 0, 0},
 };

--- a/test/test_integration.c
+++ b/test/test_integration.c
@@ -25,7 +25,8 @@ struct worker {
 	pthread_t           thread; /* System thread we run in */
 };
 
-static void *__worker_run(void *arg) {
+static void *__worker_run(void *arg)
+{
 	struct worker *w;
 	char *         leader;
 	uint64_t       heartbeat;
@@ -96,7 +97,8 @@ static void __worker_start(struct worker *     w,
                            struct test_server *server,
                            int                 i,
                            int                 a,
-                           int                 n) {
+                           int                 n)
+{
 	int err;
 
 	w->i = i;
@@ -112,7 +114,8 @@ static void __worker_start(struct worker *     w,
 	}
 }
 
-static void __worker_wait(struct worker *w) {
+static void __worker_wait(struct worker *w)
+{
 	int   err;
 	void *retval;
 
@@ -131,7 +134,8 @@ static void __worker_wait(struct worker *w) {
  *
  ******************************************************************************/
 
-static void *setup(const MunitParameter params[], void *user_data) {
+static void *setup(const MunitParameter params[], void *user_data)
+{
 	struct test_server *server;
 	const char *        errmsg;
 	int                 err;
@@ -147,7 +151,8 @@ static void *setup(const MunitParameter params[], void *user_data) {
 	return server;
 }
 
-static void tear_down(void *data) {
+static void tear_down(void *data)
+{
 	struct test_server *server = data;
 	int                 rc;
 
@@ -168,7 +173,8 @@ static void tear_down(void *data) {
  ******************************************************************************/
 
 static MunitResult test_exec_and_query(const MunitParameter params[],
-                                       void *               data) {
+                                       void *               data)
+{
 	struct test_server *      server = data;
 	struct test_client *      client;
 	char *                    leader;
@@ -231,7 +237,8 @@ static MunitResult test_exec_and_query(const MunitParameter params[],
 	return MUNIT_OK;
 }
 
-static MunitResult test_query_large(const MunitParameter params[], void *data) {
+static MunitResult test_query_large(const MunitParameter params[], void *data)
+{
 	struct test_server *      server = data;
 	struct test_client *      client;
 	char *                    leader;
@@ -297,8 +304,8 @@ static MunitResult test_query_large(const MunitParameter params[], void *data) {
 	return MUNIT_OK;
 }
 
-static MunitResult test_multi_thread(const MunitParameter params[],
-                                     void *               data) {
+static MunitResult test_multi_thread(const MunitParameter params[], void *data)
+{
 	struct test_server *      server = data;
 	struct worker *           workers;
 	struct test_client *      client;

--- a/test/test_queue.c
+++ b/test/test_queue.c
@@ -33,7 +33,8 @@ struct fixture {
  *
  ******************************************************************************/
 
-static void *setup(const MunitParameter params[], void *user_data) {
+static void *setup(const MunitParameter params[], void *user_data)
+{
 	struct fixture *f;
 	int             err;
 
@@ -42,7 +43,7 @@ static void *setup(const MunitParameter params[], void *user_data) {
 
 	f = munit_malloc(sizeof *f);
 
-	test_socket_pair_init(&f->sockets, "unix");
+	test_socket_pair_setup(params, &f->sockets);
 
 	err = uv_loop_init(&f->loop);
 	munit_assert_int(err, ==, 0);
@@ -55,7 +56,8 @@ static void *setup(const MunitParameter params[], void *user_data) {
 	return f;
 }
 
-static void tear_down(void *data) {
+static void tear_down(void *data)
+{
 	struct fixture *f = data;
 	int             err;
 
@@ -64,7 +66,7 @@ static void tear_down(void *data) {
 	err = uv_loop_close(&f->loop);
 	munit_assert_int(err, ==, 0);
 
-	test_socket_pair_close(&f->sockets);
+	test_socket_pair_tear_down(&f->sockets);
 	test_assert_no_leaks();
 }
 
@@ -74,7 +76,8 @@ static void tear_down(void *data) {
  *
  ******************************************************************************/
 
-static MunitResult test_push(const MunitParameter params[], void *data) {
+static MunitResult test_push(const MunitParameter params[], void *data)
+{
 	struct fixture *f = data;
 	int             err;
 
@@ -116,7 +119,8 @@ static MunitTest dqlite__queue_push_tests[] = {
  *
  ******************************************************************************/
 
-static MunitResult test_process(const MunitParameter params[], void *data) {
+static MunitResult test_process(const MunitParameter params[], void *data)
+{
 	struct fixture *          f = data;
 	int                       err;
 	struct dqlite__queue_item item;


### PR DESCRIPTION
This reduces latency as clients can get the first batch for rows right away (and
possibly decide to interrupt the query).