### PR TITLE
Call the xUnregister method of dqlite_cluster when closing a database

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -3,19 +3,25 @@
 
 #include <sqlite3.h>
 
+#include "../include/dqlite.h"
+
 #include "error.h"
 #include "registry.h"
 #include "stmt.h"
 
 /* Hold state for a single open SQLite database */
 struct dqlite__db {
+	/* public */
+	dqlite_cluster *cluster; /* Cluster API implementation  */
+
 	/* read-only */
 	size_t        id;    /* Database ID */
 	dqlite__error error; /* Last error occurred */
 
 	/* private */
-	sqlite3 *                    db;    /* Underlying SQLite database */
-	struct dqlite__stmt_registry stmts; /* Registry of prepared statements */
+	sqlite3 *db; /* Underlying SQLite database */
+	struct dqlite__stmt_registry
+	    stmts; /* Registry of prepared statements */
 };
 
 /* Initialize a database state object */

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -197,6 +197,8 @@ static void dqlite__gateway_open(struct dqlite__gateway *    g,
 
 	assert(db != NULL);
 
+	db->cluster = g->cluster;
+
 	rc = dqlite__db_open(db,
 	                     ctx->request->open.name,
 	                     ctx->request->open.flags,


### PR DESCRIPTION
This gives user code a chance to clean up per-db state.