### PR TITLE
Allow opening at most one database per connection

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -290,5 +290,3 @@ int dqlite__db_rollback(struct dqlite__db *db)
 
 	return SQLITE_OK;
 }
-
-DQLITE__REGISTRY_METHODS(dqlite__db_registry, dqlite__db);

--- a/src/db.h
+++ b/src/db.h
@@ -6,7 +6,6 @@
 #include "../include/dqlite.h"
 
 #include "error.h"
-#include "registry.h"
 #include "stmt.h"
 
 /* Hold state for a single open SQLite database */
@@ -60,8 +59,5 @@ int dqlite__db_commit(struct dqlite__db *db);
 
 /* Rollback a transaction. */
 int dqlite__db_rollback(struct dqlite__db *db);
-
-/* Define the database registry */
-DQLITE__REGISTRY(dqlite__db_registry, dqlite__db);
 
 #endif /* DQLITE_DB_H */

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -62,7 +62,7 @@ struct dqlite__gateway {
 	 * heartbeat or interrupt. */
 	struct dqlite__gateway_ctx ctxs[DQLITE__GATEWAY_MAX_REQUESTS];
 
-	struct dqlite__db_registry dbs; /* Registry of open databases */
+	struct dqlite__db *db; /* Open database */
 };
 
 void dqlite__gateway_init(struct dqlite__gateway *    g,


### PR DESCRIPTION
This simplifies a bit the code and the logic that will come. For now there is no
need to support multiple databases per connection, however if that ever becomes
necessary the protocol still requires the client to pass a database ID a
parameter for requests.