### PR TITLE
Re-enable splitting large queries into multiple responses

### DIFF
--- a/src/stmt.c
+++ b/src/stmt.c
@@ -427,11 +427,8 @@ int dqlite__stmt_query(struct dqlite__stmt *s, struct dqlite__message *message)
 
 	/* Insert the rows. */
 	do {
-		/* FIXME: disable batching large result sets since it seems
-		 * buggy. */
-		/*if (dqlite__message_is_large(message)) {*/
-		if (0) {
-			/* If we are already filled the static buffer, let'so
+		if (dqlite__message_is_large(message)) {
+			/* If we are already filled the static buffer, let's
 			 * break for now, we'll send more rows in a separate
 			 * response. */
 			rc = SQLITE_ROW;

--- a/test/test_stmt.c
+++ b/test/test_stmt.c
@@ -967,7 +967,7 @@ static MunitTest dqlite__stmt_query_tests[] = {
     {"/two/simple", test_query_two_simple, setup, tear_down, 0, NULL},
     {"/two/complex", test_query_two_complex, setup, tear_down, 0, NULL},
     {"/count", test_query_count, setup, tear_down, 0, NULL},
-    /*{"/large", test_query_large, setup, tear_down, 0, NULL},*/
+    {"/large", test_query_large, setup, tear_down, 0, NULL},
     {NULL, NULL, NULL, NULL, 0, NULL}};
 
 /******************************************************************************


### PR DESCRIPTION
Turns out this was not the problem.