### PR TITLE
Reset prepared statements upon failures

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -318,6 +318,7 @@ static void dqlite__gateway_exec(struct dqlite__gateway *    g,
 	} else {
 		dqlite__error_printf(&g->error, stmt->error);
 		dqlite__gateway_failure(g, ctx, rc);
+		sqlite3_reset(stmt->stmt);
 	}
 }
 
@@ -335,6 +336,8 @@ static void dqlite__gateway_query_batch(struct dqlite__gateway *    g,
 
 	rc = dqlite__stmt_query(stmt, &ctx->response.message);
 	if (rc != SQLITE_ROW && rc != SQLITE_DONE) {
+		sqlite3_reset(stmt->stmt);
+
 		/* Finalize the statement if needed. */
 		if (ctx->cleanup == DQLITE__GATEWAY_CLEANUP_FINALIZE) {
 			dqlite__db_finalize(db, stmt);
@@ -600,7 +603,7 @@ static void dqlite__gateway_loop()
 void dqlite__gateway_init(struct dqlite__gateway *    g,
                           struct dqlite__gateway_cbs *callbacks,
                           struct dqlite_cluster *     cluster,
-			  struct dqlite_logger *      logger,
+                          struct dqlite_logger *      logger,
                           struct dqlite__options *    options)
 {
 	int i;
@@ -622,7 +625,7 @@ void dqlite__gateway_init(struct dqlite__gateway *    g,
 	memcpy(&g->callbacks, callbacks, sizeof *callbacks);
 
 	g->cluster = cluster;
-	g->logger = logger;
+	g->logger  = logger;
 	g->options = options;
 
 	/* Reset all request contexts in the buffer */

--- a/src/server.c
+++ b/src/server.c
@@ -29,12 +29,7 @@ int dqlite_init(const char **errmsg)
 	 * would degrade performance but allow clients to use this process'
 	 * SQLite instance for other purposes that require multi-thread.
 	 */
-
-	/* FIXME: this setting seems to be problematic since in fact it might be
-	 * possible for clients to send queries concurrently. So it's currently
-	 * disabled, see #92. */
-	/*rc = sqlite3_config(SQLITE_CONFIG_SINGLETHREAD); */
-	rc = SQLITE_OK;
+	rc = sqlite3_config(SQLITE_CONFIG_SINGLETHREAD);
 	if (rc != SQLITE_OK) {
 		*errmsg = "failed to set SQLite to single-thread mode";
 		return DQLITE_ERROR;


### PR DESCRIPTION
It turns out that this is necessary in order to avoid SQLite considering the
statement still in progress, and returning SQLITE_BUSY upon subsequent API
calls.

Closes #92.