### PR TITLE
Fix the value of the offset passed to xShmLock when checking for read locks

### DIFF
--- a/src/format.h
+++ b/src/format.h
@@ -33,6 +33,10 @@
 /* Number of reader marks in the wal index header. */
 #define DQLITE__FORMAT_WAL_NREADER 5
 
+/* Lock index given the offset I in the aReadMark array. See the equivalent
+ * WAL_READ_LOCK definition in the wal.c file of the SQLite source code. */
+#define DQLITE__FORMAT_WAL_READ_LOCK(I) (3+(I))
+
 /* Given the page size, calculate the size of a full WAL frame (frame header
  * plus page data). */
 #define dqlite__format_wal_calc_frame_size(PAGE_SIZE)                               \

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -65,13 +65,14 @@ static int dqlite__gateway_maybe_checkpoint(void *      ctx,
 
 	/* Check each mark and associated lock. This logic is similar to the one
 	 * in the walCheckpoint function of wal.c, in the SQLite code. */
-	for (i = 1; i < DQLITE__FORMAT_WAL_NREADER; i++) {
+	for (i = 0; i < DQLITE__FORMAT_WAL_NREADER; i++) {
 		if (mx_frame > read_marks[i]) {
 			/* This read mark is set, let's check if it's also
 			 * locked. */
 			int flags = SQLITE_SHM_LOCK | SQLITE_SHM_EXCLUSIVE;
+			int lock  = DQLITE__FORMAT_WAL_READ_LOCK(i);
 
-			rc = file->pMethods->xShmLock(file, i, 1, flags);
+			rc = file->pMethods->xShmLock(file, lock, 1, flags);
 			if (rc == SQLITE_BUSY) {
 				/* It's locked. Let's postpone the checkpoint
 				 * for now. */
@@ -81,7 +82,7 @@ static int dqlite__gateway_maybe_checkpoint(void *      ctx,
 			/* Not locked. Let's release the lock we just
 			 * acquired. */
 			flags = SQLITE_SHM_UNLOCK | SQLITE_SHM_EXCLUSIVE;
-			file->pMethods->xShmLock(file, i, 1, flags);
+			file->pMethods->xShmLock(file, lock, 1, flags);
 		}
 	}
 


### PR DESCRIPTION
The offset value should be equal to the read mark array index plus 3, which is
where read locks start.

This fixes a failure noticed in LXD, see https://github.com/lxc/lxd/issues/5249.